### PR TITLE
feat: reputation breakdown tooltip on PYME profiles

### DIFF
--- a/app/pymes/[id]/page.tsx
+++ b/app/pymes/[id]/page.tsx
@@ -25,6 +25,7 @@ import {
   computePymeReputation,
   type PymeReputationTier,
 } from '@/lib/pyme-reputation'
+import { ReputationTooltip } from '@/components/reputation-tooltip'
 
 type DealRow = {
   id: string
@@ -169,7 +170,15 @@ export default async function SmbDetailPage({
             {/* Reputation badge */}
             {reputation.tier !== 'new' && (
               <div className={`shrink-0 rounded-lg border px-3 py-2 text-center ${TIER_STYLES[reputation.tier]}`}>
-                <p className="text-xs font-medium opacity-70 mb-0.5">Reputation</p>
+                <div className="mb-0.5 flex items-center justify-center gap-1">
+                  <p className="text-xs font-medium opacity-70">Reputation</p>
+                  <ReputationTooltip
+                    reputation={reputation}
+                    side="bottom"
+                    align="end"
+                    triggerClassName="h-4 w-4 text-current opacity-60 hover:opacity-100 hover:bg-transparent"
+                  />
+                </div>
                 <p className="text-sm font-semibold">{reputation.label}</p>
               </div>
             )}
@@ -232,6 +241,7 @@ export default async function SmbDetailPage({
             <CardTitle className="flex items-center gap-2 text-base">
               <ShieldCheck className="h-5 w-5 text-primary" aria-hidden />
               Repayment track record
+              <ReputationTooltip reputation={reputation} side="bottom" align="start" />
             </CardTitle>
             <CardDescription>{reputation.description} Helps investors assess repayment behavior.</CardDescription>
           </CardHeader>

--- a/app/pymes/page.tsx
+++ b/app/pymes/page.tsx
@@ -27,8 +27,10 @@ import { LATAM_COUNTRIES, SECTORS, getCountryLabel, getSectorLabel } from '@/lib
 import {
   aggregateDealsToStats,
   computePymeReputation,
+  type PymeReputation,
   type PymeReputationTier,
 } from '@/lib/pyme-reputation'
+import { ReputationTooltip } from '@/components/reputation-tooltip'
 
 type Smb = {
   id: string
@@ -43,6 +45,7 @@ type Smb = {
   sector: string | null
   deal_count?: number
   active_deals?: number
+  reputation?: PymeReputation
   reputationLabel?: string
   reputationTier?: PymeReputationTier
   totalRepaid?: number
@@ -143,6 +146,7 @@ export default function SmbsPage() {
           ...p,
           deal_count: deals.length,
           active_deals,
+          reputation: rep,
           reputationLabel: rep.label,
           reputationTier: rep.tier,
           totalRepaid: rep.stats.totalRepaid,
@@ -285,12 +289,15 @@ export default function SmbsPage() {
                         {getInitials(smb)}
                       </div>
                       <div className="flex flex-wrap items-center gap-1.5 justify-end">
-                        {smb.reputationTier && smb.reputationTier !== 'new' && (
-                          <span
-                            className={`rounded-md px-2 py-0.5 text-xs font-medium ${TIER_STYLES[smb.reputationTier]}`}
-                          >
-                            {smb.reputationLabel}
-                          </span>
+                        {smb.reputationTier && smb.reputationTier !== 'new' && smb.reputation && (
+                          <ReputationTooltip reputation={smb.reputation} side="bottom" align="end">
+                            <span
+                              className={`rounded-md px-2 py-0.5 text-xs font-medium ${TIER_STYLES[smb.reputationTier]}`}
+                              title={`Reputation: ${smb.reputationLabel}. Hover for breakdown.`}
+                            >
+                              {smb.reputationLabel}
+                            </span>
+                          </ReputationTooltip>
                         )}
                         {typeof smb.deal_count === 'number' && smb.deal_count > 0 && (
                           <span className="rounded-md bg-muted px-2 py-0.5 text-xs tabular-nums text-muted-foreground">

--- a/components/reputation-tooltip.tsx
+++ b/components/reputation-tooltip.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import * as React from 'react'
+import { Info, ShieldCheck, Coins, Activity, CheckCircle2 } from 'lucide-react'
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card'
+import { cn } from '@/lib/utils'
+import type {
+  PymeReputation,
+  PymeReputationTier,
+} from '@/lib/pyme-reputation'
+
+const TIER_DOT: Record<PymeReputationTier, string> = {
+  top_performer: 'bg-emerald-500',
+  established: 'bg-blue-500',
+  building: 'bg-amber-500',
+  new: 'bg-muted-foreground/40',
+}
+
+const TIER_RULES: { tier: PymeReputationTier; label: string; rule: string }[] = [
+  { tier: 'new', label: 'New', rule: 'No funded deals yet' },
+  { tier: 'building', label: 'Building', rule: 'At least one deal funded, none completed' },
+  { tier: 'established', label: 'Established', rule: '1+ completed deal, under top thresholds' },
+  { tier: 'top_performer', label: 'Top performer', rule: '2+ completed deals or $20,000+ repaid' },
+]
+
+const formatPrice = (value: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(value)
+
+export interface ReputationTooltipProps {
+  reputation: PymeReputation
+  /** Trigger element. Defaults to a small info icon button. */
+  children?: React.ReactNode
+  /** Tailwind class merged into the default info trigger. Ignored when children given. */
+  triggerClassName?: string
+  /** HoverCard side, passed to Radix. */
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  /** HoverCard align, passed to Radix. */
+  align?: 'start' | 'center' | 'end'
+}
+
+/**
+ * Explains how the reputation tier is computed for a PYME.
+ * Mirrors lib/pyme-reputation.ts exactly so investors can validate the score.
+ */
+export function ReputationTooltip({
+  reputation,
+  children,
+  triggerClassName,
+  side = 'bottom',
+  align = 'center',
+}: ReputationTooltipProps) {
+  const { stats, tier, label, completionRate } = reputation
+  const capitalCommitted = stats.totalRepaid + stats.currentDebt
+  const activeDeals = Math.max(0, stats.dealsFunded - stats.dealsCompleted)
+  const completionPct = Math.round(completionRate * 100)
+
+  return (
+    <HoverCard openDelay={120} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        {children ?? (
+          <button
+            type="button"
+            aria-label="How is the reputation calculated?"
+            className={cn(
+              'inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              triggerClassName,
+            )}
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        )}
+      </HoverCardTrigger>
+
+      <HoverCardContent side={side} align={align} className="w-80 p-0">
+        <div className="space-y-3 p-4">
+          <div className="flex items-start gap-2">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <div className="space-y-1">
+              <p className="text-sm font-semibold leading-none">
+                Reputation breakdown
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Current tier:{' '}
+                <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
+                  <span className={cn('inline-block h-2 w-2 rounded-full', TIER_DOT[tier])} />
+                  {label}
+                </span>
+              </p>
+            </div>
+          </div>
+
+          <ul className="space-y-2.5 text-xs">
+            <li className="flex items-start justify-between gap-3">
+              <span className="flex items-center gap-1.5 text-muted-foreground">
+                <Coins className="h-3.5 w-3.5" aria-hidden />
+                Capital committed
+              </span>
+              <span className="text-right font-medium tabular-nums">
+                {formatPrice(capitalCommitted)}
+                <span className="block text-[11px] font-normal text-muted-foreground">
+                  {formatPrice(stats.currentDebt)} active ·{' '}
+                  {formatPrice(stats.totalRepaid)} repaid
+                </span>
+              </span>
+            </li>
+
+            <li className="flex items-start justify-between gap-3">
+              <span className="flex items-center gap-1.5 text-muted-foreground">
+                <Activity className="h-3.5 w-3.5" aria-hidden />
+                Deal activity
+              </span>
+              <span className="text-right font-medium tabular-nums">
+                {stats.dealsFunded} funded
+                <span className="block text-[11px] font-normal text-muted-foreground">
+                  {stats.dealsCompleted} completed · {activeDeals} active
+                </span>
+              </span>
+            </li>
+
+            <li className="flex items-start justify-between gap-3">
+              <span className="flex items-center gap-1.5 text-muted-foreground">
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+                Repayment performance
+              </span>
+              <span className="text-right font-medium tabular-nums">
+                {stats.dealsFunded > 0 ? `${completionPct}%` : '—'}
+                <span className="block text-[11px] font-normal text-muted-foreground">
+                  completed ÷ funded
+                </span>
+              </span>
+            </li>
+          </ul>
+
+          <div className="rounded-md border border-border/60 bg-muted/40 p-2.5">
+            <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              How tiers are assigned
+            </p>
+            <ul className="space-y-1 text-[11px] text-muted-foreground">
+              {TIER_RULES.map((r) => (
+                <li
+                  key={r.tier}
+                  className={cn(
+                    'flex items-start gap-1.5',
+                    r.tier === tier && 'text-foreground font-medium',
+                  )}
+                >
+                  <span className={cn('mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full', TIER_DOT[r.tier])} />
+                  <span>
+                    <span className="font-medium">{r.label}:</span> {r.rule}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            All inputs come directly from on-chain deal status and amounts — no
+            manual edits.
+          </p>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a `ReputationTooltip` component that explains exactly how a PYME's reputation tier is computed, mirroring the logic in `lib/pyme-reputation.ts` so investors can validate the score at a glance.

The tooltip shows three breakdown rows derived from on-chain deal data plus the rule that decides each tier:

- **Capital committed** — `currentDebt + totalRepaid` (active vs. repaid)
- **Deal activity** — `dealsFunded` (split into completed and active)
- **Repayment performance** — `dealsCompleted ÷ dealsFunded`
- **Tier rules** — New / Building / Established / Top performer with the same thresholds used by `computePymeReputation` (2+ completed deals or $20k+ repaid → top performer)

Wired into the existing reputation surfaces:

- PYME directory (`/pymes`): hover the tier badge on each card
- PYME profile (`/pymes/[id]`): info icon next to the header reputation badge and next to the "Repayment track record" card title

Built on the existing `HoverCard` primitive (Radix) so it works on hover, focus, and tap with no new dependencies.

Closes #12

## Test plan

- [ ] `/pymes` — hover the colored reputation badge on a PYME card; tooltip shows tier, the three breakdown rows, and the tier rule list with the active tier highlighted
- [ ] `/pymes/[id]` for a PYME with deals — click/hover the small info icon next to "Reputation" in the header banner; same breakdown appears
- [ ] `/pymes/[id]` — hover the info icon next to "Repayment track record" title; same breakdown appears
- [ ] PYMEs with `tier === 'new'` (no funded deals) still render without the tooltip on the directory card and header (existing behavior preserved)
- [ ] Numbers in the tooltip match the values shown in the "Repayment track record" stat grid (capital committed = current debt + total repaid; completion rate = completed ÷ funded)
- [ ] Keyboard: tab to the info icon; tooltip opens on focus and closes on blur