### PR TITLE
feat: add transaction lifecycle handling across hooks

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -188,4 +188,16 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+function showLoading(message: string) {
+  return toast({ title: message })
+}
+
+function showSuccess(message: string) {
+  return toast({ title: message })
+}
+
+function showError(message: string) {
+  return toast({ title: message, variant: 'destructive' })
+}
+
+export { useToast, toast, showLoading, showSuccess, showError }

--- a/hooks/useDefindex.ts
+++ b/hooks/useDefindex.ts
@@ -3,8 +3,10 @@
 import { useState } from 'react'
 import { DefindexSDK, SupportedNetworks, DepositParams, WithdrawParams } from '@defindex/sdk'
 import { signTransaction } from '@/lib/trustless/wallet-kit'
-import { submitSignedTransaction } from '@/lib/stellar-submit'
+import { executeTransaction } from '@/lib/stellar-submit'
 import { useWalletContext } from '@/providers/wallet-provider'
+import { showLoading, showSuccess, showError } from '@/hooks/use-toast'
+import type { TxState } from '@/lib/types'
 
 const isTestnet = process.env.NEXT_PUBLIC_TRUSTLESS_NETWORK !== 'mainnet'
 const DEFINDEX_NETWORK = isTestnet
@@ -34,15 +36,16 @@ export interface WithdrawResult {
 }
 
 export function useDefindex() {
-  const [isLoading, setIsLoading] = useState(false)
+  const [txState, setTxState] = useState<TxState>('idle')
   const [error, setError] = useState<string | null>(null)
   const { walletInfo } = useWalletContext()
 
   const depositToVault = async (
     params: DepositToVaultParams
   ): Promise<DepositResult> => {
-    setIsLoading(true)
+    setTxState('loading')
     setError(null)
+    showLoading('Submitting deposit...')
 
     try {
       if (!params.amount || params.amount <= 0) {
@@ -85,7 +88,9 @@ export function useDefindex() {
         address: walletInfo.address,
       })
 
-      const result = await submitSignedTransaction(signedXdr)
+      setTxState('pending')
+      const result = await executeTransaction(signedXdr, setTxState)
+      showSuccess('Deposit confirmed')
 
       return {
         success: true,
@@ -95,20 +100,21 @@ export function useDefindex() {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to deposit to vault'
       setError(errorMessage)
+      setTxState('error')
+      showError(errorMessage)
       return {
         success: false,
         error: errorMessage,
       }
-    } finally {
-      setIsLoading(false)
     }
   }
 
   const withdrawFromVault = async (
     params: WithdrawFromVaultParams
   ): Promise<WithdrawResult> => {
-    setIsLoading(true)
+    setTxState('loading')
     setError(null)
+    showLoading('Submitting withdrawal...')
 
     try {
       if (!params.amount || params.amount <= 0) {
@@ -161,7 +167,9 @@ export function useDefindex() {
         address: walletInfo.address,
       })
 
-      const result = await submitSignedTransaction(signedXdr)
+      setTxState('pending')
+      const result = await executeTransaction(signedXdr, setTxState)
+      showSuccess('Withdrawal confirmed')
 
       return {
         success: true,
@@ -173,23 +181,20 @@ export function useDefindex() {
         ? 'Insufficient vault balance'
         : message || 'Failed to withdraw from vault'
       setError(errorMessage)
+      setTxState('error')
+      showError(errorMessage)
       return {
         success: false,
         error: errorMessage,
       }
-    } finally {
-      setIsLoading(false)
     }
   }
 
   return {
     depositToVault,
     withdrawFromVault,
-    isLoading,
+    txState,
+    isLoading: txState === 'loading' || txState === 'pending',
     error,
   }
 }
-
-// Test manual: en cualquier componente con wallet conectada,
-// llamar: await depositToVault({ vaultAddress: "VAULT_ADDR", amount: 1000000 })
-// llamar: await withdrawFromVault({ vaultAddress: "VAULT_ADDR", amount: 5000000 })

--- a/lib/hooks/useEscrowIntegration.ts
+++ b/lib/hooks/useEscrowIntegration.ts
@@ -12,6 +12,8 @@ import type {
 import { signTransaction } from '@/lib/trustless/wallet-kit'
 import { USDC_TRUSTLINE } from '@/lib/trustless/trustlines'
 import { MERCATO_PLATFORM_ADDRESS } from '@/lib/trustless/config'
+import { showLoading, showSuccess, showError } from '@/hooks/use-toast'
+import type { TxState } from '@/lib/types'
 
 export interface EscrowMilestone {
   description: string
@@ -31,7 +33,7 @@ export interface InitializeEscrowParams {
 }
 
 export function useEscrowIntegration() {
-  const [isLoading, setIsLoading] = useState(false)
+  const [txState, setTxState] = useState<TxState>('idle')
   const [error, setError] = useState<string | null>(null)
 
   const { deployEscrow } = useInitializeEscrow()
@@ -46,8 +48,9 @@ export function useEscrowIntegration() {
     transactionHash?: string
     error?: string
   }> => {
-    setIsLoading(true)
+    setTxState('loading')
     setError(null)
+    showLoading('Submitting transaction...')
 
     try {
       if (!MERCATO_PLATFORM_ADDRESS) {
@@ -95,6 +98,7 @@ export function useEscrowIntegration() {
         address: params.signer,
       })
 
+      setTxState('pending')
       const sendResponse = await sendTransaction(signedXdr)
 
       if (sendResponse.status !== 'SUCCESS') {
@@ -104,6 +108,9 @@ export function useEscrowIntegration() {
             : 'Failed to submit transaction'
         )
       }
+
+      setTxState('success')
+      showSuccess('Transaction confirmed')
 
       const contractId =
         'contractId' in sendResponse ? sendResponse.contractId : undefined
@@ -120,18 +127,19 @@ export function useEscrowIntegration() {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to initialize escrow'
       setError(errorMessage)
+      setTxState('error')
+      showError(errorMessage)
       return {
         success: false,
         error: errorMessage,
       }
-    } finally {
-      setIsLoading(false)
     }
   }
 
   return {
     initializeAndDeployEscrow,
-    isLoading,
+    txState,
+    isLoading: txState === 'loading' || txState === 'pending',
     error,
   }
 }

--- a/lib/stellar-submit.ts
+++ b/lib/stellar-submit.ts
@@ -5,6 +5,7 @@
 
 import { Horizon, Transaction } from '@stellar/stellar-sdk'
 import { NETWORK_PASSPHRASE } from '@/lib/trustless/wallet-kit'
+import type { TxState } from '@/lib/types'
 
 const isTestnet = process.env.NEXT_PUBLIC_TRUSTLESS_NETWORK !== 'mainnet'
 const HORIZON_URL = isTestnet
@@ -24,4 +25,19 @@ export async function submitSignedTransaction(signedXdr: string): Promise<{
   const tx = new Transaction(signedXdr, NETWORK_PASSPHRASE)
   const result = await server.submitTransaction(tx)
   return { hash: result.hash, successful: result.successful }
+}
+
+export async function executeTransaction(
+  signedXdr: string,
+  onStateChange: (state: TxState) => void,
+): Promise<{ hash: string; successful: boolean }> {
+  onStateChange('loading')
+  try {
+    const result = await submitSignedTransaction(signedXdr)
+    onStateChange('success')
+    return result
+  } catch (err) {
+    onStateChange('error')
+    throw err
+  }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,6 @@
-export type DealStatus = 
+export type TxState = 'idle' | 'loading' | 'pending' | 'success' | 'error'
+
+export type DealStatus =
   | 'awaiting_funding' 
   | 'funded' 
   | 'in_progress' 


### PR DESCRIPTION
## Description

Standardises transaction lifecycle handling across all blockchain interactions. Every transaction now exposes `idle → loading → pending → success/error` states with consistent user feedback via toasts, so failed or in-progress transactions are never silent.

## Changes

- **`lib/types.ts`**: Export shared `TxState = 'idle' | 'loading' | 'pending' | 'success' | 'error'`
- **`hooks/use-toast.ts`**: Export standalone helpers `showLoading`, `showSuccess`, `showError`
- **`lib/stellar-submit.ts`**: Add `executeTransaction(signedXdr, onStateChange)` wrapper that drives `TxState` around `submitSignedTransaction`
- **`hooks/useDefindex.ts`**: Replace `isLoading` boolean with `TxState`; show lifecycle toasts for deposit and withdraw; keep `isLoading` computed alias for backwards compatibility
- **`lib/hooks/useEscrowIntegration.ts`**: Same pattern applied to escrow init flow; exposes `txState` on return value

## Closes

Closes #6

## Notes

- `isLoading` is kept as a derived value (`txState === 'loading' || txState === 'pending'`) on both hooks so existing consumers do not break.
- Pre-existing TypeScript errors in unrelated files were present before this PR and do not affect the build.