### PR TITLE
Feat/available capital calculation

### DIFF
--- a/hooks/useDefindex.ts
+++ b/hooks/useDefindex.ts
@@ -149,8 +149,8 @@ export const useDefindex = (options?: UseDefindexOptions) => {
     availableCapital: normalizeUSDC(
       getAvailableCapital({
         wallet: walletBalance,
-        reserved: 0,
-        stake: 0,
+        reserved: 0, // TODO(#4): connect when Capital State Model is implemented
+        stake: 0,    // TODO: connect from useStake() hook when available
       })
     ),
     isLoadingBalances,

--- a/hooks/useDefindex.ts
+++ b/hooks/useDefindex.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { normalizeUSDC } from '@/lib/format'
+import { getAvailableCapital } from '@/lib/capital'
 import { useWallet } from '@/hooks/use-wallet'
 
 type VaultAction<TArgs extends unknown[] = unknown[], TResult = unknown> = (
@@ -145,6 +146,13 @@ export const useDefindex = (options?: UseDefindexOptions) => {
     refreshBalances,
     vaultBalance: normalizeUSDC(vaultBalance),
     walletBalance: normalizeUSDC(walletBalance),
+    availableCapital: normalizeUSDC(
+      getAvailableCapital({
+        wallet: walletBalance,
+        reserved: 0,
+        stake: 0,
+      })
+    ),
     isLoadingBalances,
     balanceError,
   }

--- a/lib/capital.ts
+++ b/lib/capital.ts
@@ -26,6 +26,18 @@ export function availableCapital(state: CapitalState): number {
   return state.wallet
 }
 
+export function getAvailableCapital({
+  wallet,
+  reserved,
+  stake,
+}: {
+  wallet: number
+  reserved: number
+  stake: number
+}): number {
+  return normalize(Math.max(wallet - reserved - stake, 0))
+}
+
 function normalize(value: number): number {
   if (!Number.isFinite(value) || value < 0) return 0
   return Number(value.toFixed(2))


### PR DESCRIPTION
## Summary
Adds getAvailableCapital helper and exposes it via useDefindex hook
for use across allocation flows.

## Changes
- Added getAvailableCapital({ wallet, reserved, stake }) to lib/capital.ts
- Extended useDefindex to calculate and expose availableCapital

## Testing
Tested with `tsc --noEmit` — no errors in modified files. Function is
pure and verifiable by passing any numeric values.

## Notes
- stake and reserved default to `0` with TODOs marking where to
  connect real values: stake from a future `useStake()` hook,
  reserved from Issue #4 (Capital State Model).
- Error in `investor-capital-overview.tsx:98` is preexisting from
  Issue #7, not introduced by this PR.
- pnpm lint and pnpm build failures are preexisting repo issues
  unrelated to this PR.


Closes #13 