### PR TITLE
Feat/supplier product images

### DIFF
--- a/components/supplier-profile/supplier-product-card.tsx
+++ b/components/supplier-profile/supplier-product-card.tsx
@@ -17,57 +17,69 @@ export function SupplierProductCard({ product, onEdit, onDelete }: SupplierProdu
   const { t } = useI18n()
 
   return (
-    <article className="flex flex-col rounded-2xl border border-border/70 bg-card p-4 shadow-sm transition-shadow hover:shadow-md">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <h3 className="truncate font-medium leading-snug">{product.name}</h3>
-          <p className="mt-0.5 text-xs text-muted-foreground">{getCategoryLabel(product.category)}</p>
+    <article className="flex flex-col rounded-2xl border border-border/70 bg-card shadow-sm transition-shadow hover:shadow-md overflow-hidden">
+      {product.image_url && (
+        <div className="relative h-40 w-full shrink-0 border-b border-border/60 bg-muted/20">
+          <img
+            src={product.image_url}
+            alt={product.name}
+            className="h-full w-full object-cover"
+          />
         </div>
-        <div className="flex shrink-0 gap-0.5">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={onEdit}
-            aria-label={t('supplierProfile.editAria', { name: product.name })}
-          >
-            <Pencil className="h-4 w-4" aria-hidden />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 text-destructive hover:text-destructive"
-            onClick={onDelete}
-            aria-label={t('supplierProfile.deleteAria', { name: product.name })}
-          >
-            <Trash2 className="h-4 w-4" aria-hidden />
-          </Button>
-        </div>
-      </div>
-
-      <p className="mt-3 text-xl font-semibold tabular-nums tracking-tight">
-        {formatCurrency(product.price_per_unit)}
-        <span className="ml-1 text-sm font-normal text-muted-foreground">/ unit</span>
-      </p>
-
-      <dl className="mt-3 grid gap-1.5 text-xs text-muted-foreground">
-        {product.minimum_order != null && (
-          <div className="flex justify-between gap-2">
-            <dt>{t('supplierProfile.tableMinOrder')}</dt>
-            <dd className="font-medium text-foreground">{formatCurrency(product.minimum_order)}</dd>
-          </div>
-        )}
-        {product.delivery_time && (
-          <div className="flex justify-between gap-2">
-            <dt>{t('supplierProfile.tableDelivery')}</dt>
-            <dd className="truncate font-medium text-foreground">{product.delivery_time}</dd>
-          </div>
-        )}
-      </dl>
-
-      {product.description && (
-        <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{product.description}</p>
       )}
+
+      <div className="flex flex-col flex-1 p-4">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h3 className="truncate font-medium leading-snug">{product.name}</h3>
+            <p className="mt-0.5 text-xs text-muted-foreground">{getCategoryLabel(product.category)}</p>
+          </div>
+          <div className="flex shrink-0 gap-0.5">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onEdit}
+              aria-label={t('supplierProfile.editAria', { name: product.name })}
+            >
+              <Pencil className="h-4 w-4" aria-hidden />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:text-destructive"
+              onClick={onDelete}
+              aria-label={t('supplierProfile.deleteAria', { name: product.name })}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden />
+            </Button>
+          </div>
+        </div>
+
+        <p className="mt-3 text-xl font-semibold tabular-nums tracking-tight">
+          {formatCurrency(product.price_per_unit)}
+          <span className="ml-1 text-sm font-normal text-muted-foreground">/ unit</span>
+        </p>
+
+        <dl className="mt-3 grid gap-1.5 text-xs text-muted-foreground">
+          {product.minimum_order != null && (
+            <div className="flex justify-between gap-2">
+              <dt>{t('supplierProfile.tableMinOrder')}</dt>
+              <dd className="font-medium text-foreground">{formatCurrency(product.minimum_order)}</dd>
+            </div>
+          )}
+          {product.delivery_time && (
+            <div className="flex justify-between gap-2">
+              <dt>{t('supplierProfile.tableDelivery')}</dt>
+              <dd className="truncate font-medium text-foreground">{product.delivery_time}</dd>
+            </div>
+          )}
+        </dl>
+
+        {product.description && (
+          <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">{product.description}</p>
+        )}
+      </div>
     </article>
   )
 }

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+import { useRef, useState } from 'react'
+import { Upload } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -21,6 +25,63 @@ type SupplierProductFormProps = {
 
 export function SupplierProductForm({ formProduct, onChange }: SupplierProductFormProps) {
   const { t } = useI18n()
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = () => {
+    setIsDragging(false)
+  }
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(false)
+    if (e.dataTransfer.files && e.dataTransfer.files[0]) {
+      handleFile(e.dataTransfer.files[0])
+    }
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      handleFile(e.target.files[0])
+    }
+  }
+
+  const handleFile = (file: File) => {
+    const validTypes = ['image/jpeg', 'image/png', 'image/webp']
+    if (!validTypes.includes(file.type)) {
+      toast.error(t('supplierProfile.toastImageTypeError'))
+      return
+    }
+
+    const maxSize = 5 * 1024 * 1024
+    if (file.size > maxSize) {
+      toast.error(t('supplierProfile.toastImageSizeError'))
+      return
+    }
+
+    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
+      URL.revokeObjectURL(formProduct.imagePreview)
+    }
+
+    const previewUrl = URL.createObjectURL(file)
+    onChange({ imageFile: file, imagePreview: previewUrl })
+  }
+
+  const handleRemoveImage = () => {
+    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
+      URL.revokeObjectURL(formProduct.imagePreview)
+    }
+    onChange({ imageFile: null, imagePreview: null })
+  }
+
+  const triggerFileInput = () => {
+    fileInputRef.current?.click()
+  }
 
   return (
     <div className="space-y-4">
@@ -102,6 +163,69 @@ export function SupplierProductForm({ formProduct, onChange }: SupplierProductFo
           rows={3}
           className="resize-none"
         />
+      </div>
+      <div className="space-y-2">
+        <Label>{t('supplierProfile.formProductImage')}</Label>
+        {formProduct.imagePreview ? (
+          <div className="flex items-center gap-4 p-4 border border-border/70 bg-muted/20 rounded-xl">
+            <div className="relative h-20 w-20 shrink-0 rounded-lg overflow-hidden border border-border/60 bg-muted/40">
+              <img
+                src={formProduct.imagePreview}
+                alt="Product Preview"
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="text-sm font-medium text-foreground truncate">
+                {formProduct.imageFile ? formProduct.imageFile.name : t('supplierProfile.formProductImage')}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {formProduct.imageFile
+                  ? `${(formProduct.imageFile.size / (1024 * 1024)).toFixed(2)} MB`
+                  : ''}
+              </p>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                className="h-8 text-xs rounded-full mt-1"
+                onClick={handleRemoveImage}
+              >
+                {t('supplierProfile.formProductImageRemove')}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+            onClick={triggerFileInput}
+            className={`flex flex-col items-center justify-center p-6 border-2 border-dashed rounded-xl cursor-pointer transition-all ${
+              isDragging
+                ? 'border-primary bg-primary/5'
+                : 'border-muted-foreground/20 hover:border-primary/50 bg-muted/5 hover:bg-muted/10'
+            }`}
+          >
+            <input
+              type="file"
+              ref={fileInputRef}
+              accept="image/png, image/jpeg, image/webp"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+            <Upload className="h-8 w-8 text-muted-foreground mb-2" />
+            <p className="text-sm font-medium text-foreground text-center hidden sm:block">
+              {t('supplierProfile.formProductImageSelect')}
+            </p>
+            <p className="text-sm font-medium text-foreground text-center sm:hidden">
+              {t('supplierProfile.formProductImageSelectMobile')}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t('supplierProfile.formProductImageHint')}
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/hooks/use-supplier-profile.ts
+++ b/hooks/use-supplier-profile.ts
@@ -251,6 +251,25 @@ export function useSupplierProfile() {
     return true
   }
 
+  const getPathFromUrl = useCallback((url: string) => {
+    const marker = '/storage/v1/object/public/products/'
+    const index = url.indexOf(marker)
+    if (index !== -1) {
+      return decodeURIComponent(url.substring(index + marker.length))
+    }
+    return null
+  }, [])
+
+  const deleteStorageFile = useCallback(async (url: string) => {
+    const path = getPathFromUrl(url)
+    if (path) {
+      const { error } = await supabase.storage.from('products').remove([path])
+      if (error) {
+        console.error('Error deleting file from storage:', error)
+      }
+    }
+  }, [supabase, getPathFromUrl])
+
   const openAddDialog = () => {
     setFormProduct(EMPTY_PRODUCT_FORM)
     setAddDialogOpen(true)
@@ -265,6 +284,8 @@ export function useSupplierProfile() {
       description: p.description ?? '',
       minimum_order: p.minimum_order != null ? String(p.minimum_order) : '',
       delivery_time: p.delivery_time ?? '',
+      imageFile: null,
+      imagePreview: p.image_url ?? null,
     })
     setEditingProduct(p)
   }
@@ -302,7 +323,32 @@ export function useSupplierProfile() {
         .select()
         .single()
       if (error) throw error
-      setProducts((prev) => [...prev, data as SupplierProduct])
+
+      let finalProduct = { ...data } as SupplierProduct
+
+      if (formProduct.imageFile) {
+        const filePath = `${user.id}/${selectedCompanyId}/${data.id}/${formProduct.imageFile.name}`
+        const { error: uploadError } = await supabase.storage
+          .from('products')
+          .upload(filePath, formProduct.imageFile)
+        if (uploadError) throw uploadError
+
+        const { data: urlData } = supabase.storage
+          .from('products')
+          .getPublicUrl(filePath)
+
+        const publicUrl = urlData.publicUrl
+
+        const { error: updateError } = await supabase
+          .from('supplier_products')
+          .update({ image_url: publicUrl })
+          .eq('id', data.id)
+        if (updateError) throw updateError
+
+        finalProduct.image_url = publicUrl
+      }
+
+      setProducts((prev) => [...prev, finalProduct])
       setProductCounts((prev) => ({ ...prev, [selectedCompanyId]: (prev[selectedCompanyId] ?? 0) + 1 }))
       setAddDialogOpen(false)
       setFormProduct(EMPTY_PRODUCT_FORM)
@@ -317,7 +363,7 @@ export function useSupplierProfile() {
 
   const handleUpdateProduct = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!editingProduct) return
+    if (!editingProduct || !user || !selectedCompanyId) return
     const { name, category, price, minOrder, deliveryTime } = parseProductForm()
     if (!name || !category || Number.isNaN(price) || price <= 0) {
       toast.error(t('supplierProfile.toastProductFields'))
@@ -325,6 +371,29 @@ export function useSupplierProfile() {
     }
     setFormSaving(true)
     try {
+      let imageUrlToSave: string | null = editingProduct.image_url
+
+      if (formProduct.imageFile) {
+        if (editingProduct.image_url) {
+          await deleteStorageFile(editingProduct.image_url)
+        }
+        const filePath = `${user.id}/${selectedCompanyId}/${editingProduct.id}/${formProduct.imageFile.name}`
+        const { error: uploadError } = await supabase.storage
+          .from('products')
+          .upload(filePath, formProduct.imageFile, { upsert: true })
+        if (uploadError) throw uploadError
+
+        const { data: urlData } = supabase.storage
+          .from('products')
+          .getPublicUrl(filePath)
+        imageUrlToSave = urlData.publicUrl
+      } else if (!formProduct.imagePreview) {
+        if (editingProduct.image_url) {
+          await deleteStorageFile(editingProduct.image_url)
+        }
+        imageUrlToSave = null
+      }
+
       const { error } = await supabase
         .from('supplier_products')
         .update({
@@ -334,10 +403,12 @@ export function useSupplierProfile() {
           description: formProduct.description.trim() || null,
           minimum_order: minOrder != null && !Number.isNaN(minOrder) && minOrder >= 0 ? minOrder : null,
           delivery_time: deliveryTime,
+          image_url: imageUrlToSave,
           updated_at: new Date().toISOString(),
         })
         .eq('id', editingProduct.id)
       if (error) throw error
+
       setProducts((prev) =>
         prev.map((p) =>
           p.id === editingProduct.id
@@ -349,6 +420,7 @@ export function useSupplierProfile() {
                 description: formProduct.description.trim() || null,
                 minimum_order: minOrder != null && !Number.isNaN(minOrder) && minOrder >= 0 ? minOrder : null,
                 delivery_time: deliveryTime,
+                image_url: imageUrlToSave,
               }
             : p,
         ),
@@ -367,6 +439,9 @@ export function useSupplierProfile() {
   const handleDeleteProduct = async () => {
     if (!deleteProduct || !selectedCompanyId) return
     try {
+      if (deleteProduct.image_url) {
+        await deleteStorageFile(deleteProduct.image_url)
+      }
       const { error } = await supabase.from('supplier_products').delete().eq('id', deleteProduct.id)
       if (error) throw error
       setProducts((prev) => prev.filter((p) => p.id !== deleteProduct.id))

--- a/lib/supplier-profile/types.ts
+++ b/lib/supplier-profile/types.ts
@@ -16,6 +16,7 @@ export type SupplierProduct = {
   description: string | null
   minimum_order: number | null
   delivery_time: string | null
+  image_url: string | null
 }
 
 export type ProductFormState = {
@@ -25,6 +26,8 @@ export type ProductFormState = {
   description: string
   minimum_order: string
   delivery_time: string
+  imageFile: File | null
+  imagePreview: string | null
 }
 
 export const EMPTY_PRODUCT_FORM: ProductFormState = {
@@ -34,6 +37,8 @@ export const EMPTY_PRODUCT_FORM: ProductFormState = {
   description: '',
   minimum_order: '',
   delivery_time: '',
+  imageFile: null,
+  imagePreview: null,
 }
 
 export type CompanyFormState = {

--- a/messages/extended-en.json
+++ b/messages/extended-en.json
@@ -804,7 +804,14 @@
     "formDescriptionPh": "e.g. Industrial wheat flour (25kg & 50kg sacks)",
     "placeholderCompanyPh": "e.g. Acme Supplies",
     "placeholderPhonePh": "e.g. +595 21 123 456",
-    "placeholderBioPh": "e.g., We supply wholesale ingredients to bakeries and restaurants…"
+    "placeholderBioPh": "e.g., We supply wholesale ingredients to bakeries and restaurants…",
+    "formProductImage": "Product Image",
+    "formProductImageSelect": "Drag & drop an image here, or click to select",
+    "formProductImageSelectMobile": "Click to select product image",
+    "formProductImageHint": "PNG, JPG or WEBP. Max 5MB.",
+    "formProductImageRemove": "Remove image",
+    "toastImageSizeError": "File is too large. Maximum size is 5MB.",
+    "toastImageTypeError": "Unsupported file format. Please upload a JPEG, PNG, or WEBP image."
   },
   "reputationTooltip": {
     "ariaLabel": "How is the reputation calculated?",

--- a/messages/extended-es.json
+++ b/messages/extended-es.json
@@ -804,7 +804,14 @@
     "formDescriptionPh": "ej. Harina de trigo industrial (sacos 25 y 50 kg)",
     "placeholderCompanyPh": "ej. Suministros Acme",
     "placeholderPhonePh": "ej. +595 21 123 456",
-    "placeholderBioPh": "ej. Suministramos ingredientes mayoristas a panaderías y restaurantes…"
+    "placeholderBioPh": "ej. Suministramos ingredientes mayoristas a panaderías y restaurantes…",
+    "formProductImage": "Imagen del producto",
+    "formProductImageSelect": "Arrastra y suelta una imagen aquí, o haz clic para seleccionar",
+    "formProductImageSelectMobile": "Haz clic para seleccionar la imagen del producto",
+    "formProductImageHint": "PNG, JPG o WEBP. Máx. 5MB.",
+    "formProductImageRemove": "Eliminar imagen",
+    "toastImageSizeError": "El archivo es demasiado grande. El tamaño máximo es 5MB.",
+    "toastImageTypeError": "Formato de archivo no soportado. Por favor sube una imagen JPEG, PNG o WEBP."
   },
   "reputationTooltip": {
     "ariaLabel": "¿Cómo se calcula la reputación?",

--- a/scripts/011_latam_supplier_fields.sql
+++ b/scripts/011_latam_supplier_fields.sql
@@ -3,8 +3,19 @@
 alter table public.profiles
   add column if not exists sector text;
 
+-- Create supplier_products table if it does not exist
+create table if not exists public.supplier_products (
+  id uuid primary key default gen_random_uuid(),
+  supplier_id uuid not null references public.profiles(id) on delete cascade,
+  name text not null,
+  category text not null,
+  price_per_unit numeric not null,
+  description text,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
 -- Product-level: minimum order (USD), typical delivery time (e.g. "7–10 days")
--- supplier_products table must already exist
 alter table public.supplier_products
   add column if not exists minimum_order numeric,
   add column if not exists delivery_time text;

--- a/supabase/migrations/20260528000100_add_product_images.sql
+++ b/supabase/migrations/20260528000100_add_product_images.sql
@@ -1,0 +1,37 @@
+-- Alter supplier_products table if it exists
+ALTER TABLE IF EXISTS public.supplier_products
+  ADD COLUMN IF NOT EXISTS image_url TEXT DEFAULT NULL;
+
+-- Create products bucket in Supabase storage
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('products', 'products', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Allow public select access to the products bucket
+CREATE POLICY "Public Read Access"
+  ON storage.objects FOR SELECT
+  USING ( bucket_id = 'products' );
+
+-- Allow suppliers to insert files under their own folder segment: products/{user_id}/...
+CREATE POLICY "Insert own product images"
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    bucket_id = 'products'
+    AND (auth.uid())::text = split_part(name, '/', 1)
+  );
+
+-- Allow suppliers to update files under their own folder segment
+CREATE POLICY "Update own product images"
+  ON storage.objects FOR UPDATE
+  USING (
+    bucket_id = 'products'
+    AND (auth.uid())::text = split_part(name, '/', 1)
+  );
+
+-- Allow suppliers to delete files under their own folder segment
+CREATE POLICY "Delete own product images"
+  ON storage.objects FOR DELETE
+  USING (
+    bucket_id = 'products'
+    AND (auth.uid())::text = split_part(name, '/', 1)
+  );


### PR DESCRIPTION
# Pull Request: Add supplier product image upload support backed by Supabase Storage

## Overview
This PR implements end-to-end support for product image uploads in the **Add Product** and **Edit Product** forms within the Supplier Dashboard. Visual assets are critical for SMEs/suppliers to display their product catalogs on the Mercato platform. Image uploads are backed by Supabase Storage and integrated directly into the database.

---

## Key Changes

### 1. Database & Storage Migration (`supabase/migrations/` & `scripts/`)
* Created migration `20260528000100_add_product_images.sql` to add the `image_url` column to the `supplier_products` table.
* Provisioned a public `products` bucket in Supabase Storage with Row Level Security (RLS) enabled.
* Configured policies allowing public read access to product images, and restricting write/update/delete operations to the authenticated user matching the first directory segment of the object path (i.e. `products/{user_id}/...`).
* Prepend table creation for `supplier_products` in `scripts/011_latam_supplier_fields.sql` to resolve structural dependencies for fresh local database boot.

### 2. TypeScript Types (`lib/supplier-profile/`)
* Extended `SupplierProduct` type with the `image_url: string | null` field.
* Extended `ProductFormState` with `imageFile: File | null` and `imagePreview: string | null` fields to handle local uploads, previews, and DB state sync.

### 3. Drag-and-Drop Image Uploader Component (`components/supplier-profile/`)
* Implemented a premium, responsive drag-and-drop zone (`SupplierProductForm`) with interactive dragover states.
* Enforced file type validation (only `JPEG/PNG/WEBP` allowed) and file size validation (max `5MB`).
* Leveraged local object-URLs (`URL.createObjectURL`) for immediate visual preview and ensured proper cleanup (`URL.revokeObjectURL`) to prevent memory leaks when files are replaced or removed.
* Added a localized **Remove image** action button.

### 4. Hook Logic & Storage Operations (`hooks/use-supplier-profile.ts`)
* Added utility resolver `deleteStorageFile` to parse file path segments from public Supabase Storage URLs.
* **Create**: Product row is inserted first to retrieve the ID, then the image is uploaded to `products/{user_id}/{company_id}/{product_id}/{filename}`. The product row is then updated with the public URL and synced to the local catalog state.
* **Update**: Deletes the old image from the storage bucket if replaced or cleared, and updates the database row.
* **Delete**: Removes associated image file from Supabase Storage prior to deleting the product row from the database.

### 5. Card UI Rendering (`components/supplier-profile/`)
* Restructured `SupplierProductCard` to render product images at the top of the card using a fixed-height (`h-40`) container with `object-cover` and rounded-top edges.
* Wrapped text and CTA button content in padding containers to sit cleanly below the image.
* Maintained original compact, text-only layout configuration when no image is present.

### 6. Translations (`messages/`)
* Added translation keys under the `supplierProfile` namespace in both English (`messages/extended-en.json`) and Spanish (`messages/extended-es.json`) dictionaries to support validation toast alerts and interactive uploader text.

---

## Verification
* Checked local TypeScript compilation using `tsc --noEmit` and ensured no compilation errors were introduced.
* Bootstrapped local Supabase containers and applied migrations.
* Verified schema validation:
  * Table `supplier_products` has the `image_url` column.
  * Bucket `products` exists and RLS policies are applied successfully.


## Closes #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supplier products now support image uploads with drag-and-drop or file selection
  * Product cards display uploaded images alongside product information
  * Image validation enforces JPEG, PNG, or WebP formats with a 5MB maximum size
  * Users can remove product images when needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mercato-supply-chain/mercato-dapp/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->