### PR TITLE
feat(suppliers): add product image display to supplier detail page

### DIFF
--- a/app/suppliers/[id]/page.tsx
+++ b/app/suppliers/[id]/page.tsx
@@ -34,6 +34,7 @@ type ProductRow = {
   description: string | null
   minimum_order: number | null
   delivery_time: string | null
+  image_url: string | null
 }
 
 type DealRow = {
@@ -125,7 +126,7 @@ export default async function SupplierDetailPage({
       supabase.from('profiles').select('email').eq('id', company.owner_id).single(),
       supabase
         .from('supplier_products')
-        .select('id, name, category, price_per_unit, description, minimum_order, delivery_time')
+        .select('id, name, category, price_per_unit, description, minimum_order, delivery_time, image_url')
         .eq('supplier_id', id)
         .order('name'),
       supabase.from('deals').select('id', { count: 'exact', head: true }).eq('supplier_id', id),
@@ -315,6 +316,13 @@ export default async function SupplierDetailPage({
                         key={p.id}
                         className="flex flex-wrap items-start justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3 transition-colors hover:bg-muted/40"
                       >
+                        {p.image_url && (
+                          <img
+                            src={p.image_url}
+                            alt={p.name}
+                            className="h-16 w-16 shrink-0 rounded-lg object-cover"
+                          />
+                        )}
                         <div className="min-w-0 flex-1">
                           <div className="flex flex-wrap items-center gap-2">
                             <p className="font-medium">{p.name}</p>


### PR DESCRIPTION

- Close #36 

**feat: display product images in supplier detail view (#36)**

## Summary

Closes #36. Adds product image thumbnails to the consumer-facing supplier detail page (`/suppliers/[id]`), completing the loop on the image upload feature introduced in #35.

## Changes

**`app/suppliers/[id]/page.tsx`**
- Added `image_url: string | null` to the local `ProductRow` type
- Extended the `supplier_products` Supabase select query to include `image_url`
- Conditionally renders a `16×16` thumbnail in each product list item when `image_url` is present

## Behavior

- Products **with** an image show a rounded thumbnail (`h-16 w-16 object-cover rounded-lg`) to the left of the text block
- Products **without** an image render exactly as before — no placeholder, no broken image icon
- Layout stays intact at all breakpoints including the `lg:col-span-2` products card on mobile

## Dependencies

Depends on #35 (`image_url TEXT` column in `supplier_products` and the `SupplierProduct` type update) — both already merged.

## Testing

1. Open a supplier detail page for a supplier with at least one product that has an uploaded image → thumbnail appears inline
2. Open a supplier detail page for a supplier with products that have no image → rows look identical to before
3. Resize to mobile width → no layout overflow or image distortion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product images now display in supplier catalog listings when available, providing visual previews of inventory items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mercato-supply-chain/mercato-dapp/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->