### PR TITLE
fix: stop tracking auto-generated next-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 # Next.js
 .next/
 out/
+next-env.d.ts
 
 # Environment variables (never commit secrets)
 .env

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Fixes the `next-env.d.ts` route types path issue described in #47.

## Context

The issue asks for `next-env.d.ts` to import from the stable `./.next/types/routes.d.ts` instead of the dev-only `./.next/dev/types/routes.d.ts`.

While investigating, I found that the root cause is that Next.js 16 (with `isolatedDevBuild`) **overwrites** `next-env.d.ts` with the dev-only path on every `next dev` run. This is how the incorrect path ended up committed in the first place — so a one-line edit alone is not durable, since the next `npm run dev` reverts it.

The two upstream Next.js fixes referenced in the issue (vercel/next.js#88103 and #88428) were both **reverted**, so there is no framework-level fix in this version.

## Solution

Per the [Next.js TypeScript docs](https://nextjs.org/docs/app/api-reference/config/typescript), `next-env.d.ts` is auto-generated and should not be edited or committed. This PR:

- Adds `next-env.d.ts` to `.gitignore`
- Removes it from git tracking (`git rm --cached`)

This guarantees the incorrect dev-only path can never be re-committed, so CI and production builds always resolve route types from the correct location — durably across dev and build modes.

## Verification

1. `git rm --cached next-env.d.ts` + added to `.gitignore`
2. Ran `npm run dev` (regenerates the file locally with the dev path)
3. `git status` shows no tracked changes to `next-env.d.ts` ✅

## Note for maintainers

If you'd prefer the literal one-line edit committed instead of gitignoring the file, I'm happy to switch — but it would re-break on the next local `next dev` run. Open to your preference.

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude auto-generated Next.js TypeScript declaration files from version control, ensuring cleaner repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->