### PR TITLE
fix: enforce MIME type and file size limits on products bucket

### DIFF
--- a/supabase/migrations/20260528000100_add_product_images.sql
+++ b/supabase/migrations/20260528000100_add_product_images.sql
@@ -3,9 +3,9 @@ ALTER TABLE IF EXISTS public.supplier_products
   ADD COLUMN IF NOT EXISTS image_url TEXT DEFAULT NULL;
 
 -- Create products bucket in Supabase storage
-INSERT INTO storage.buckets (id, name, public)
-VALUES ('products', 'products', true)
-ON CONFLICT (id) DO NOTHING;
+INSERT INTO storage.buckets (id, name, public, allowed_mime_types, file_size_limit)
+VALUES ('products', 'products', true, ARRAY['image/jpeg', 'image/png', 'image/webp'], 5000000)
+ON CONFLICT (id) DO UPDATE SET allowed_mime_types = EXCLUDED.allowed_mime_types, file_size_limit = EXCLUDED.file_size_limit;
 
 -- Allow public select access to the products bucket
 CREATE POLICY "Public Read Access"


### PR DESCRIPTION
## Summary

Enforces MIME type and file size limits on the `products` Supabase Storage bucket, as described in #46.

## Problem

The migration `supabase/migrations/20260528000100_add_product_images.sql` created the `products` bucket with only `(id, name, public)` and `ON CONFLICT (id) DO NOTHING`. As a result, `allowed_mime_types` and `file_size_limit` were never set — and if the bucket already existed, the conflict clause silently skipped it. This allowed unsupported file types and oversized uploads to bypass server-side validation via the Storage API, relying only on client-side checks.

## Fix

Updated the bucket `INSERT` to include `allowed_mime_types` and `file_size_limit`, and switched to `ON CONFLICT (id) DO UPDATE SET` so the limits are always enforced whether the bucket is newly created or already exists:

```sql
INSERT INTO storage.buckets (id, name, public, allowed_mime_types, file_size_limit)
VALUES ('products', 'products', true, ARRAY['image/jpeg', 'image/png', 'image/webp'], 5000000)
ON CONFLICT (id) DO UPDATE SET
  allowed_mime_types = EXCLUDED.allowed_mime_types,
  file_size_limit = EXCLUDED.file_size_limit;
```

- `allowed_mime_types`: `image/jpeg`, `image/png`, `image/webp`
- `file_size_limit`: `5000000` (5 MB in bytes)

The rest of the migration (the `image_url` column and the storage RLS policies) is unchanged.

## Verification

Applied the full migration sequence to a clean Supabase project, then confirmed the bucket settings:

```sql
SELECT id, name, public, allowed_mime_types, file_size_limit
FROM storage.buckets
WHERE id = 'products';
```

Result: the `products` bucket now has `allowed_mime_types = {image/jpeg, image/png, image/webp}` and `file_size_limit = 5000000`, so unsupported types and oversized uploads are now rejected server-side. 

<img width="707" height="112" alt="image" src="https://github.com/user-attachments/assets/8b5d7abd-93c4-46cc-b5a0-4c9ab74ecd24" />



Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Product image upload capability added with support for JPEG, PNG, and WebP formats (5MB file size limit per image)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->