### PR TITLE
Refactor: split admin DeFindex vault panel into focused components

### DIFF
--- a/components/admin/admin-defindex-vault-panel.tsx
+++ b/components/admin/admin-defindex-vault-panel.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
-import { toast } from 'sonner'
-import { Button } from '@/components/ui/button'
 import {
   Card,
   CardContent,
@@ -10,268 +8,54 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { Separator } from '@/components/ui/separator'
-import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
-import {
-  AlertCircle,
-  Landmark,
-  Loader2,
-  ChevronDown,
-  ChevronUp,
-  Copy,
-  CheckCircle2,
-  ExternalLink,
-  Wand2,
-  Info,
-} from 'lucide-react'
-import { VaultDeploymentChecklist } from '@/components/admin/vault-deployment-checklist'
-import { resolveDeployedVaultAddress } from '@/lib/defindex/extract-vault-address'
-import { signTransaction } from '@/lib/trustless/wallet-kit'
-import { useWallet } from '@/hooks/use-wallet'
-import { usePollarSession } from '@/providers/pollar-provider'
-import type { SendTransactionResponse } from '@defindex/sdk'
+import { AlertCircle, CheckCircle2, Landmark } from 'lucide-react'
+import { LAST_DEPLOY_STORAGE_KEY, VaultCreatePanel } from '@/components/admin/vault-create-panel'
+import { VaultDepositPanel } from '@/components/admin/vault-deposit-panel'
+import { VaultRebalancePanel } from '@/components/admin/vault-rebalance-panel'
+import { useAdminVaultMonitor } from '@/hooks/use-admin-vault-monitor'
 
 type Props = {
   configuredVaultAddress: string
 }
 
-interface VaultFormState {
-  name: string
-  symbol: string
-  vaultFeeBps: string
-  upgradable: boolean
-  emergencyManager: string
-  feeReceiver: string
-  manager: string
-  rebalanceManager: string
-  assetAddress: string
-  strategyAddress: string
-  strategyName: string
-}
-
-const DEFAULTS: VaultFormState = {
-  name: 'Mercato Vault',
-  symbol: 'mVLT',
-  vaultFeeBps: '100',
-  upgradable: true,
-  emergencyManager: '',
-  feeReceiver: '',
-  manager: '',
-  rebalanceManager: '',
-  assetAddress: '',
-  strategyAddress: '',
-  strategyName: 'Primary Strategy',
-}
-
-// Verified testnet contract addresses from DeFindex testnet.contracts.json
-// https://github.com/paltalabs/defindex/blob/main/public/testnet.contracts.json
-const LAST_DEPLOY_STORAGE_KEY = 'mercato:admin-last-vault-deploy'
-
-const TESTNET_PRESETS = {
-  blendUsdc: {
-    label: 'BlendUSDC',
-    asset: 'CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU',
-    strategy: 'CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY',
-    strategyName: 'USDC Blend Strategy',
-  },
-  xlm: {
-    label: 'XLM',
-    asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
-    strategy: 'CDVLOSPJPQOTB6ZCWO5VSGTOLGMKTXSFWYTUP572GTPNOWX4F76X3HPM',
-    strategyName: 'XLM Blend Strategy',
-  },
-} as const
-
-async function readErrorMessage(response: Response): Promise<string> {
-  try {
-    const data = (await response.json()) as { error?: unknown }
-    if (typeof data?.error === 'string' && data.error) return data.error
-  } catch {
-    /* ignore */
-  }
-  return `Request failed (${response.status})`
-}
-
-function buildConfig(form: VaultFormState, callerAddress: string): Record<string, unknown> {
-  const feeBps = Number(form.vaultFeeBps)
-  return {
-    caller: callerAddress,
-    name: form.name.trim(),
-    symbol: form.symbol.trim(),
-    vaultFeeBps: Number.isFinite(feeBps) ? feeBps : 100,
-    upgradable: form.upgradable,
-    roles: {
-      emergencyManager: form.emergencyManager.trim() || callerAddress,
-      feeReceiver: form.feeReceiver.trim() || callerAddress,
-      manager: form.manager.trim() || callerAddress,
-      rebalanceManager: form.rebalanceManager.trim() || callerAddress,
-    },
-    assets: form.assetAddress.trim()
-      ? [
-          {
-            address: form.assetAddress.trim(),
-            strategies: form.strategyAddress.trim()
-              ? [
-                  {
-                    address: form.strategyAddress.trim(),
-                    name: form.strategyName.trim() || 'Primary Strategy',
-                    paused: false,
-                  },
-                ]
-              : [],
-          },
-        ]
-      : [],
-  }
-}
-
 export function AdminDefindexVaultPanel({ configuredVaultAddress }: Props) {
-  const { walletInfo, provider } = useWallet()
-  const pollar = usePollarSession()
-  const [form, setForm] = useState<VaultFormState>(DEFAULTS)
-  const [busy, setBusy] = useState(false)
-  const [showAdvanced, setShowAdvanced] = useState(false)
-  const [copied, setCopied] = useState(false)
-  const [lastTxHash, setLastTxHash] = useState<string | null>(null)
-  const [lastVaultAddress, setLastVaultAddress] = useState<string | null>(null)
-
   const hasVaultEnv = Boolean(configuredVaultAddress.trim())
+  const [sessionVaultAddress, setSessionVaultAddress] = useState<string | null>(null)
 
   useEffect(() => {
+    if (configuredVaultAddress.trim()) return
     try {
       const raw = sessionStorage.getItem(LAST_DEPLOY_STORAGE_KEY)
       if (!raw) return
-      const parsed = JSON.parse(raw) as { txHash?: string; vaultAddress?: string }
-      if (parsed.txHash) setLastTxHash(parsed.txHash)
-      if (parsed.vaultAddress) setLastVaultAddress(parsed.vaultAddress)
+      const parsed = JSON.parse(raw) as { vaultAddress?: string }
+      if (parsed.vaultAddress?.trim()) setSessionVaultAddress(parsed.vaultAddress.trim())
     } catch {
       /* ignore */
     }
-  }, [])
+  }, [configuredVaultAddress])
 
-  useEffect(() => {
-    if (!lastTxHash) return
-    try {
-      sessionStorage.setItem(
-        LAST_DEPLOY_STORAGE_KEY,
-        JSON.stringify({ txHash: lastTxHash, vaultAddress: lastVaultAddress }),
-      )
-    } catch {
-      /* ignore */
-    }
-  }, [lastTxHash, lastVaultAddress])
+  const activeVaultAddress = configuredVaultAddress.trim() || sessionVaultAddress || ''
+  const monitorEnabled = Boolean(activeVaultAddress)
 
-  const set = (key: keyof VaultFormState) =>
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      setForm((prev) => ({ ...prev, [key]: e.target.value }))
+  const { data, refresh } = useAdminVaultMonitor({
+    vaultOverride: activeVaultAddress || null,
+    enabled: monitorEnabled,
+    pollMs: monitorEnabled ? 30_000 : 0,
+  })
 
-  const fillPreset = (preset: typeof TESTNET_PRESETS[keyof typeof TESTNET_PRESETS]) => {
-    setForm((prev) => ({
-      ...prev,
-      assetAddress: preset.asset,
-      strategyAddress: preset.strategy,
-      strategyName: preset.strategyName,
-    }))
-  }
-
-  const previewJson = JSON.stringify(
-    buildConfig(form, walletInfo?.address ?? 'G…your-wallet'),
-    null,
-    2
-  )
-
-  const handleCopyJson = async () => {
-    await navigator.clipboard.writeText(previewJson)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  const signAndSubmit = useCallback(
-    async (unsignedXdr: string, signerAddress: string): Promise<SendTransactionResponse> => {
-      if (provider === 'pollar') {
-        // Pollar embedded wallet: signs + submits in one step, returns tx hash directly
-        const txHash = await pollar.signAndSubmitTx(unsignedXdr)
-        return { success: true, txHash } as SendTransactionResponse
-      }
-
-      // External wallet (Freighter / Albedo): sign then submit via our API
-      const signedXdr = await signTransaction({
-        unsignedTransaction: unsignedXdr,
-        address: signerAddress,
-      })
-      const submitResponse = await fetch('/api/defindex/submit', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ xdr: signedXdr }),
-      })
-      if (!submitResponse.ok) throw new Error(await readErrorMessage(submitResponse))
-      return (await submitResponse.json()) as SendTransactionResponse
+  const handleDeployed = useCallback(
+    (payload: { txHash: string | null; vaultAddress: string | null }) => {
+      if (payload.vaultAddress) setSessionVaultAddress(payload.vaultAddress)
+      if (payload.vaultAddress) void refresh()
     },
-    [pollar, provider]
+    [refresh],
   )
 
-  const onDeploy = useCallback(async () => {
-    const address = walletInfo?.address?.trim()
-    if (!address) {
-      toast.error('Connect your admin wallet first.')
-      return
-    }
-    if (!form.assetAddress.trim()) {
-      toast.error('Asset address is required to create a vault.')
-      return
-    }
-
-    const config = buildConfig(form, address)
-    setBusy(true)
-    setLastTxHash(null)
-    setLastVaultAddress(null)
-    try {
-      const res = await fetch('/api/defindex/admin/create-vault', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(config),
-      })
-      if (!res.ok) throw new Error(await readErrorMessage(res))
-
-      const createPayload = (await res.json()) as {
-        xdr?: string
-        simulationResponse?: string
-      }
-      const { xdr } = createPayload
-      if (!xdr) throw new Error('No XDR returned from DeFindex.')
-
-      const submitted = await signAndSubmit(xdr, address)
-      if (submitted?.success === false) {
-        toast.error('Transaction was not successful on-chain.')
-        return
-      }
-
-      const vaultAddress = resolveDeployedVaultAddress(createPayload, submitted)
-      if (submitted?.txHash) setLastTxHash(submitted.txHash)
-      if (vaultAddress) setLastVaultAddress(vaultAddress)
-
-      toast.success('Vault deployed! Check the next steps below.', {
-        description: vaultAddress
-          ? `Vault: ${vaultAddress.slice(0, 8)}…`
-          : submitted?.txHash
-            ? `Tx: ${submitted.txHash}`
-            : undefined,
-      })
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Vault creation failed.')
-    } finally {
-      setBusy(false)
-    }
-  }, [form, signAndSubmit, walletInfo?.address])
+  const depositDone = (data?.totals.tvlDisplay ?? 0) > 0
 
   return (
     <div className="space-y-4">
-      {/* Current vault status */}
       <Card>
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2">
@@ -309,250 +93,23 @@ export function AdminDefindexVaultPanel({ configuredVaultAddress }: Props) {
         </CardContent>
       </Card>
 
-      {/* Create vault form */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">Create new vault</CardTitle>
-          <CardDescription>
-            Fill in the parameters or use the testnet presets below. Role fields left blank default to your connected wallet.
-            See the{' '}
-            <a
-              href="https://docs.defindex.io/api-integration-guide/creating-a-defindex-vault"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-0.5 underline underline-offset-2"
-            >
-              DeFindex vault guide <ExternalLink className="h-3 w-3" />
-            </a>{' '}
-            for full documentation.
-          </CardDescription>
-        </CardHeader>
+      <VaultCreatePanel onDeployed={handleDeployed} />
 
-        <CardContent className="space-y-6">
-          {walletInfo?.address && provider !== 'pollar' && (
-            <div className="flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-xs text-blue-800 dark:text-blue-200">
-              <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>
-                Signing with <strong>Freighter / Albedo</strong>. If you&apos;re using a Pollar embedded wallet, sign in via the wallet button and it will be used automatically.
-              </span>
-            </div>
-          )}
-
-          {/* Testnet presets */}
-          <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-4">
-            <div className="mb-2 flex items-center gap-2">
-              <Info className="h-3.5 w-3.5 shrink-0 text-blue-500" aria-hidden />
-              <p className="text-xs font-semibold text-blue-700 dark:text-blue-400">Testnet quick-fill</p>
-            </div>
-            <p className="mb-3 text-xs text-muted-foreground">
-              On testnet, DeFindex strategies use <strong>BlendUSDC</strong> — a test token from{' '}
-              <a href="https://testnet.blend.capital" target="_blank" rel="noreferrer" className="underline underline-offset-2">
-                testnet.blend.capital
-              </a>
-              , <em>not</em> regular USDC. Get BlendUSDC from their faucet before deploying a USDC vault.
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(TESTNET_PRESETS).map(([key, preset]) => (
-                <Button
-                  key={key}
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 gap-1.5 text-xs"
-                  onClick={() => fillPreset(preset)}
-                  disabled={busy}
-                >
-                  <Wand2 className="h-3 w-3" aria-hidden />
-                  Fill {preset.label} preset
-                </Button>
-              ))}
-            </div>
-          </div>
-
-          {/* Basic info */}
-          <div>
-            <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Vault identity</p>
-            <div className="grid gap-4 sm:grid-cols-3">
-              <div className="space-y-1.5">
-                <Label htmlFor="vault-name">Name</Label>
-                <Input
-                  id="vault-name"
-                  value={form.name}
-                  onChange={set('name')}
-                  placeholder="Mercato Vault"
-                  disabled={busy}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="vault-symbol">Symbol</Label>
-                <Input
-                  id="vault-symbol"
-                  value={form.symbol}
-                  onChange={set('symbol')}
-                  placeholder="mVLT"
-                  disabled={busy}
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="vault-fee">
-                  Fee (bps)
-                  <span className="ml-1.5 text-xs text-muted-foreground">
-                    {Number(form.vaultFeeBps) / 100}%
-                  </span>
-                </Label>
-                <Input
-                  id="vault-fee"
-                  type="number"
-                  min={0}
-                  max={10000}
-                  value={form.vaultFeeBps}
-                  onChange={set('vaultFeeBps')}
-                  placeholder="100"
-                  disabled={busy}
-                />
-              </div>
-            </div>
-            <div className="mt-4 flex items-center gap-3">
-              <Switch
-                id="vault-upgradable"
-                checked={form.upgradable}
-                onCheckedChange={(v) => setForm((p) => ({ ...p, upgradable: v }))}
-                disabled={busy}
-              />
-              <Label htmlFor="vault-upgradable" className="cursor-pointer">
-                Upgradable contract
-                <span className="ml-1 text-xs text-muted-foreground">(recommended for testnet)</span>
-              </Label>
-            </div>
-          </div>
-
-          <Separator />
-
-          {/* Asset & strategy */}
-          <div>
-            <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Asset &amp; strategy</p>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div className="space-y-1.5">
-                <Label htmlFor="asset-address">
-                  Asset contract address <span className="text-destructive">*</span>
-                </Label>
-                <Input
-                  id="asset-address"
-                  value={form.assetAddress}
-                  onChange={set('assetAddress')}
-                  placeholder="C… (use preset above for testnet)"
-                  className="font-mono text-xs"
-                  disabled={busy}
-                />
-                <p className="text-[11px] text-muted-foreground">
-                  Testnet BlendUSDC: <code className="rounded bg-muted px-0.5">CAQCFVL…RCJU</code>
-                </p>
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="strategy-address">Strategy contract address</Label>
-                <Input
-                  id="strategy-address"
-                  value={form.strategyAddress}
-                  onChange={set('strategyAddress')}
-                  placeholder="C… (leave blank for no strategy)"
-                  className="font-mono text-xs"
-                  disabled={busy}
-                />
-              </div>
-              {form.strategyAddress.trim() && (
-                <div className="space-y-1.5 sm:col-span-2">
-                  <Label htmlFor="strategy-name">Strategy label</Label>
-                  <Input
-                    id="strategy-name"
-                    value={form.strategyName}
-                    onChange={set('strategyName')}
-                    placeholder="Primary Strategy"
-                    disabled={busy}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-
-          <Separator />
-
-          {/* Roles */}
-          <div>
-            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Roles</p>
-            <p className="mb-3 text-xs text-muted-foreground">
-              Leave any field blank to default to your connected wallet address (
-              <span className="font-mono">{walletInfo?.address ? walletInfo.address.slice(0, 8) + '…' : 'not connected'}</span>).
-            </p>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {(
-                [
-                  { id: 'manager', label: 'Manager', key: 'manager' },
-                  { id: 'rebalance-manager', label: 'Rebalance manager', key: 'rebalanceManager' },
-                  { id: 'fee-receiver', label: 'Fee receiver', key: 'feeReceiver' },
-                  { id: 'emergency-manager', label: 'Emergency manager', key: 'emergencyManager' },
-                ] as const
-              ).map(({ id, label, key }) => (
-                <div key={id} className="space-y-1.5">
-                  <Label htmlFor={id}>{label}</Label>
-                  <Input
-                    id={id}
-                    value={form[key]}
-                    onChange={set(key)}
-                    placeholder="G… (defaults to your wallet)"
-                    className="font-mono text-xs"
-                    disabled={busy}
-                  />
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* JSON preview (collapsible) */}
-          <div className="rounded-lg border border-border bg-muted/30">
-            <button
-              type="button"
-              className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium"
-              onClick={() => setShowAdvanced((p) => !p)}
-            >
-              <span>Preview JSON payload</span>
-              {showAdvanced ? <ChevronUp className="h-4 w-4" aria-hidden /> : <ChevronDown className="h-4 w-4" aria-hidden />}
-            </button>
-            {showAdvanced && (
-              <div className="relative border-t border-border">
-                <pre className="max-h-64 overflow-auto p-4 text-[11px] leading-relaxed text-muted-foreground">
-                  {previewJson}
-                </pre>
-                <button
-                  type="button"
-                  onClick={() => void handleCopyJson()}
-                  className="absolute right-3 top-3 rounded-md border border-border bg-background p-1.5 text-muted-foreground hover:text-foreground"
-                  title="Copy JSON"
-                >
-                  {copied ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
-                </button>
-              </div>
-            )}
-          </div>
-
-          {lastTxHash && (
-            <VaultDeploymentChecklist
-              txHash={lastTxHash}
-              vaultAddress={lastVaultAddress}
-              managerAddress={walletInfo?.address ?? ''}
-              strategyAddress={form.strategyAddress.trim()}
-            />
-          )}
-
-          <Button
-            className="gap-2"
-            disabled={busy || !form.assetAddress.trim()}
-            onClick={() => void onDeploy()}
-          >
-            {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Landmark className="h-4 w-4" aria-hidden />}
-            {busy ? 'Deploying vault…' : 'Build XDR & deploy vault'}
-          </Button>
-        </CardContent>
-      </Card>
+      {activeVaultAddress && data && (
+        <>
+          <VaultDepositPanel
+            vaultAddress={activeVaultAddress}
+            monitor={data}
+            onSuccess={() => void refresh()}
+          />
+          <VaultRebalancePanel
+            vaultAddress={activeVaultAddress}
+            monitor={data}
+            depositDone={depositDone}
+            onSuccess={() => void refresh()}
+          />
+        </>
+      )}
     </div>
   )
 }

--- a/components/admin/admin-vault-activation.tsx
+++ b/components/admin/admin-vault-activation.tsx
@@ -1,177 +1,27 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
-import {
-  ArrowRight,
-  CheckCircle2,
-  Circle,
-  Loader2,
-  Sprout,
-  Wallet,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { CheckCircle2, Circle, Sprout } from 'lucide-react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { VaultAssetTrustlineCard } from '@/components/admin/vault-asset-trustline-card'
+import { VaultDepositPanel } from '@/components/admin/vault-deposit-panel'
+import { VaultRebalancePanel } from '@/components/admin/vault-rebalance-panel'
 import { useAdminVaultTransactions } from '@/hooks/use-admin-vault-transactions'
-import { isMissingTrustlineError } from '@/lib/stellar/vault-asset-trustline'
 import { useI18n } from '@/lib/i18n/provider'
-import { displayToRawTokenAmount, getPublicDefindexAssetDecimals } from '@/lib/defindex/client-amounts'
-import {
-  minInitDepositDisplay,
-  VAULT_MIN_INIT_DEPOSIT_RAW,
-} from '@/lib/defindex/vault-activation'
 import type { VaultMonitorPayload } from '@/lib/defindex/vault-monitor'
-import { formatCurrency, formatDecimal } from '@/lib/format'
+
 type AdminVaultActivationProps = {
   vaultAddress: string
   monitor: VaultMonitorPayload
   onSuccess: () => void
 }
 
-type StrategyOption = {
-  assetSymbol: string
-  address: string
-  name: string
-  paused: boolean
-}
-
 export function AdminVaultActivation({ vaultAddress, monitor, onSuccess }: AdminVaultActivationProps) {
   const { messages } = useI18n()
   const m = messages.adminVaultMonitor
-  const { walletAddress, provider, submitAdminXdr } = useAdminVaultTransactions()
-
-  const decimals = getPublicDefindexAssetDecimals()
-  const minDisplay = minInitDepositDisplay(decimals)
-
-  const [depositDisplay, setDepositDisplay] = useState(String(minDisplay))
-  const [busy, setBusy] = useState<'deposit' | 'rebalance' | null>(null)
-  const [trustlineReady, setTrustlineReady] = useState(false)
-
-  const assetCount = Math.max(monitor.assets.length, 1)
-  const primaryAsset = monitor.assets[0]
-
-  const strategyOptions = useMemo((): StrategyOption[] => {
-    const out: StrategyOption[] = []
-    for (const asset of monitor.assets) {
-      for (const s of asset.strategies) {
-        out.push({
-          assetSymbol: asset.symbol,
-          address: s.address,
-          name: s.name,
-          paused: s.paused,
-        })
-      }
-    }
-    return out
-  }, [monitor.assets])
-
-  const defaultStrategy =
-    strategyOptions.find((s) => !s.paused)?.address ?? strategyOptions[0]?.address ?? ''
-
-  const [strategyAddress, setStrategyAddress] = useState(defaultStrategy)
-
-  useEffect(() => {
-    if (defaultStrategy) setStrategyAddress(defaultStrategy)
-  }, [defaultStrategy])
+  const { walletAddress, provider } = useAdminVaultTransactions()
 
   const depositDone = monitor.totals.tvlDisplay > 0
   const rebalanceDone =
     monitor.totals.investedDisplay > 0 && monitor.totals.idlePercent < 90
-
-  const idleRaw = useMemo(() => {
-    const raw = Number(primaryAsset?.idleRaw ?? 0)
-    return Number.isFinite(raw) ? Math.floor(raw) : 0
-  }, [primaryAsset?.idleRaw])
-
-  const callerMatchesRebalance =
-    walletAddress &&
-    (walletAddress === monitor.roles.rebalanceManager ||
-      walletAddress === monitor.roles.manager)
-
-  const buildAmountsArray = (rawFirstAsset: number): number[] => {
-    const amounts = new Array(assetCount).fill(0) as number[]
-    amounts[0] = rawFirstAsset
-    return amounts
-  }
-
-  const onDeposit = async () => {
-    const display = Number(depositDisplay)
-    const raw = displayToRawTokenAmount(display, decimals)
-    if (raw < VAULT_MIN_INIT_DEPOSIT_RAW) {
-      toast.error(m.depositTooSmall.replace('{min}', formatDecimal(minDisplay, { maxFractionDigits: 7 })))
-      return
-    }
-
-    setBusy('deposit')
-    try {
-      const result = await submitAdminXdr('/api/defindex/admin/deposit', {
-        vault: vaultAddress,
-        amounts: buildAmountsArray(raw),
-        invest: false,
-        slippageBps: 100,
-      })
-      if (result?.success === false) {
-        toast.error(m.txFailed)
-        return
-      }
-      toast.success(m.depositSuccess)
-      onSuccess()
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : m.depositFailed
-      toast.error(isMissingTrustlineError(msg) ? m.trustMissingError : msg)
-    } finally {
-      setBusy(null)
-    }
-  }
-
-  const onRebalance = async () => {
-    if (!strategyAddress) {
-      toast.error(m.noStrategy)
-      return
-    }
-    if (idleRaw <= 0) {
-      toast.error(m.noIdle)
-      return
-    }
-    if (walletAddress && !callerMatchesRebalance) {
-      toast.error(m.callerRoleWarning)
-    }
-
-    setBusy('rebalance')
-    try {
-      const result = await submitAdminXdr('/api/defindex/admin/rebalance', {
-        vault: vaultAddress,
-        instructions: [
-          {
-            type: 'Invest',
-            strategy_address: strategyAddress,
-            amount: idleRaw,
-          },
-        ],
-      })
-      if (result?.success === false) {
-        toast.error(m.txFailed)
-        return
-      }
-      toast.success(m.rebalanceSuccess)
-      onSuccess()
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : m.rebalanceFailed
-      toast.error(isMissingTrustlineError(msg) ? m.trustMissingError : msg)
-    } finally {
-      setBusy(null)
-    }
-  }
 
   if (rebalanceDone && depositDone) {
     return (
@@ -206,127 +56,32 @@ export function AdminVaultActivation({ vaultAddress, monitor, onSuccess }: Admin
         {walletAddress && provider !== 'pollar' && (
           <p className="text-xs text-muted-foreground">
             {m.signingAs.replace('{address}', `${walletAddress.slice(0, 8)}…${walletAddress.slice(-4)}`)}
-            {!callerMatchesRebalance && (
-              <span className="mt-1 block text-amber-700 dark:text-amber-300">{m.callerRoleHint}</span>
-            )}
           </p>
         )}
 
         <ol className="space-y-4">
           <li className="flex gap-3">
             <StepIcon done={depositDone} />
-            <div className="min-w-0 flex-1 space-y-3">
-              <div>
-                <p className="font-medium">{m.stepDepositTitle}</p>
-                <p className="text-sm text-muted-foreground">{m.stepDepositDesc}</p>
-              </div>
-              {!depositDone && primaryAsset && (
-                <VaultAssetTrustlineCard
-                  assetContract={primaryAsset.address}
-                  assetSymbol={primaryAsset.symbol}
-                  assetName={primaryAsset.name}
-                  onTrustlineReady={() => setTrustlineReady(true)}
-                />
-              )}
-              {!depositDone && (
-                <div className="flex flex-wrap items-end gap-3">
-                  <div className="min-w-[10rem] flex-1 space-y-1.5">
-                    <Label htmlFor="admin-vault-deposit">{m.depositAmountLabel}</Label>
-                    <Input
-                      id="admin-vault-deposit"
-                      type="number"
-                      min={minDisplay}
-                      step="any"
-                      value={depositDisplay}
-                      onChange={(e) => setDepositDisplay(e.target.value)}
-                      disabled={busy !== null}
-                    />
-                    <p className="text-[11px] text-muted-foreground">
-                      {m.depositMinHint.replace('{min}', formatDecimal(minDisplay, { maxFractionDigits: 7 }))}
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    className="gap-2"
-                    disabled={busy !== null || !walletAddress || !trustlineReady}
-                    onClick={() => void onDeposit()}
-                  >
-                    {busy === 'deposit' ? (
-                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                    ) : (
-                      <Wallet className="h-4 w-4" aria-hidden />
-                    )}
-                    {m.depositCta}
-                  </Button>
-                </div>
-              )}
-              {depositDone && (
-                <p className="text-sm text-emerald-700 dark:text-emerald-400">
-                  {m.depositDone.replace('{tvl}', formatCurrency(monitor.totals.tvlDisplay))}
-                </p>
-              )}
+            <div className="min-w-0 flex-1">
+              <VaultDepositPanel
+                vaultAddress={vaultAddress}
+                monitor={monitor}
+                onSuccess={onSuccess}
+                variant="embedded"
+              />
             </div>
           </li>
 
           <li className="flex gap-3">
             <StepIcon done={rebalanceDone} />
-            <div className="min-w-0 flex-1 space-y-3">
-              <div>
-                <p className="font-medium">{m.stepRebalanceTitle}</p>
-                <p className="text-sm text-muted-foreground">{m.stepRebalanceDesc}</p>
-              </div>
-              {!rebalanceDone && (
-                <>
-                  {!depositDone ? (
-                    <p className="text-sm text-muted-foreground">{m.rebalanceAfterDeposit}</p>
-                  ) : (
-                    <div className="space-y-3">
-                      {strategyOptions.length > 1 ? (
-                        <div className="space-y-1.5">
-                          <Label>{m.strategyLabel}</Label>
-                          <Select value={strategyAddress} onValueChange={setStrategyAddress}>
-                            <SelectTrigger>
-                              <SelectValue placeholder={m.strategyLabel} />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {strategyOptions.map((s) => (
-                                <SelectItem key={s.address} value={s.address} disabled={s.paused}>
-                                  {s.assetSymbol} · {s.name}
-                                  {s.paused ? ` (${m.paused})` : ''}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </div>
-                      ) : strategyOptions[0] ? (
-                        <p className="text-xs text-muted-foreground">
-                          {m.strategyTarget.replace('{name}', strategyOptions[0].name)}
-                        </p>
-                      ) : null}
-                      <p className="text-sm">
-                        {m.idleToInvest.replace('{amount}', formatCurrency(primaryAsset?.idleDisplay ?? 0))}
-                      </p>
-                      <Button
-                        type="button"
-                        variant="secondary"
-                        className="gap-2"
-                        disabled={busy !== null || !walletAddress || idleRaw <= 0}
-                        onClick={() => void onRebalance()}
-                      >
-                        {busy === 'rebalance' ? (
-                          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
-                        ) : (
-                          <ArrowRight className="h-4 w-4" aria-hidden />
-                        )}
-                        {m.rebalanceCta}
-                      </Button>
-                    </div>
-                  )}
-                </>
-              )}
-              {rebalanceDone && (
-                <p className="text-sm text-emerald-700 dark:text-emerald-400">{m.rebalanceDone}</p>
-              )}
+            <div className="min-w-0 flex-1">
+              <VaultRebalancePanel
+                vaultAddress={vaultAddress}
+                monitor={monitor}
+                depositDone={depositDone}
+                onSuccess={onSuccess}
+                variant="embedded"
+              />
             </div>
           </li>
         </ol>

--- a/components/admin/admin-vault-monitor.tsx
+++ b/components/admin/admin-vault-monitor.tsx
@@ -29,7 +29,7 @@ import { formatCurrency, formatPercent } from '@/lib/format'
 import type { VaultMonitorAlertSeverity } from '@/lib/defindex/vault-monitor'
 import { cn } from '@/lib/utils'
 
-const LAST_DEPLOY_STORAGE_KEY = 'mercato:admin-last-vault-deploy'
+import { LAST_DEPLOY_STORAGE_KEY } from '@/components/admin/vault-create-panel'
 
 type AdminVaultMonitorProps = {
   configuredVaultAddress: string

--- a/components/admin/vault-create-panel.tsx
+++ b/components/admin/vault-create-panel.tsx
@@ -1,0 +1,480 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { Switch } from '@/components/ui/switch'
+import {
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Landmark,
+  Loader2,
+  Wand2,
+} from 'lucide-react'
+import { VaultDeploymentChecklist } from '@/components/admin/vault-deployment-checklist'
+import { useAdminVaultTransactions } from '@/hooks/use-admin-vault-transactions'
+import { resolveDeployedVaultAddress } from '@/lib/defindex/extract-vault-address'
+import type { SendTransactionResponse } from '@defindex/sdk'
+
+export const LAST_DEPLOY_STORAGE_KEY = 'mercato:admin-last-vault-deploy'
+
+interface VaultFormState {
+  name: string
+  symbol: string
+  vaultFeeBps: string
+  upgradable: boolean
+  emergencyManager: string
+  feeReceiver: string
+  manager: string
+  rebalanceManager: string
+  assetAddress: string
+  strategyAddress: string
+  strategyName: string
+}
+
+const DEFAULTS: VaultFormState = {
+  name: 'Mercato Vault',
+  symbol: 'mVLT',
+  vaultFeeBps: '100',
+  upgradable: true,
+  emergencyManager: '',
+  feeReceiver: '',
+  manager: '',
+  rebalanceManager: '',
+  assetAddress: '',
+  strategyAddress: '',
+  strategyName: 'Primary Strategy',
+}
+
+const TESTNET_PRESETS = {
+  blendUsdc: {
+    label: 'BlendUSDC',
+    asset: 'CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU',
+    strategy: 'CALLOM5I7XLQPPOPQMYAHUWW4N7O3JKT42KQ4ASEEVBXDJQNJOALFSUY',
+    strategyName: 'USDC Blend Strategy',
+  },
+  xlm: {
+    label: 'XLM',
+    asset: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+    strategy: 'CDVLOSPJPQOTB6ZCWO5VSGTOLGMKTXSFWYTUP572GTPNOWX4F76X3HPM',
+    strategyName: 'XLM Blend Strategy',
+  },
+} as const
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: unknown }
+    if (typeof data?.error === 'string' && data.error) return data.error
+  } catch {
+    /* ignore */
+  }
+  return `Request failed (${response.status})`
+}
+
+function buildConfig(form: VaultFormState, callerAddress: string): Record<string, unknown> {
+  const feeBps = Number(form.vaultFeeBps)
+  return {
+    caller: callerAddress,
+    name: form.name.trim(),
+    symbol: form.symbol.trim(),
+    vaultFeeBps: Number.isFinite(feeBps) ? feeBps : 100,
+    upgradable: form.upgradable,
+    roles: {
+      emergencyManager: form.emergencyManager.trim() || callerAddress,
+      feeReceiver: form.feeReceiver.trim() || callerAddress,
+      manager: form.manager.trim() || callerAddress,
+      rebalanceManager: form.rebalanceManager.trim() || callerAddress,
+    },
+    assets: form.assetAddress.trim()
+      ? [
+          {
+            address: form.assetAddress.trim(),
+            strategies: form.strategyAddress.trim()
+              ? [
+                  {
+                    address: form.strategyAddress.trim(),
+                    name: form.strategyName.trim() || 'Primary Strategy',
+                    paused: false,
+                  },
+                ]
+              : [],
+          },
+        ]
+      : [],
+  }
+}
+
+type VaultCreatePanelProps = {
+  onDeployed?: (payload: { txHash: string | null; vaultAddress: string | null }) => void
+}
+
+export function VaultCreatePanel({ onDeployed }: VaultCreatePanelProps) {
+  const { walletAddress, provider, signAndSubmit } = useAdminVaultTransactions()
+  const [form, setForm] = useState<VaultFormState>(DEFAULTS)
+  const [busy, setBusy] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const [lastTxHash, setLastTxHash] = useState<string | null>(null)
+  const [lastVaultAddress, setLastVaultAddress] = useState<string | null>(null)
+
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(LAST_DEPLOY_STORAGE_KEY)
+      if (!raw) return
+      const parsed = JSON.parse(raw) as { txHash?: string; vaultAddress?: string }
+      if (parsed.txHash) setLastTxHash(parsed.txHash)
+      if (parsed.vaultAddress) setLastVaultAddress(parsed.vaultAddress)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!lastTxHash) return
+    try {
+      sessionStorage.setItem(
+        LAST_DEPLOY_STORAGE_KEY,
+        JSON.stringify({ txHash: lastTxHash, vaultAddress: lastVaultAddress }),
+      )
+    } catch {
+      /* ignore */
+    }
+  }, [lastTxHash, lastVaultAddress])
+
+  const set = (key: keyof VaultFormState) =>
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((prev) => ({ ...prev, [key]: e.target.value }))
+
+  const fillPreset = (preset: typeof TESTNET_PRESETS[keyof typeof TESTNET_PRESETS]) => {
+    setForm((prev) => ({
+      ...prev,
+      assetAddress: preset.asset,
+      strategyAddress: preset.strategy,
+      strategyName: preset.strategyName,
+    }))
+  }
+
+  const previewJson = JSON.stringify(
+    buildConfig(form, walletAddress ?? 'G…your-wallet'),
+    null,
+    2,
+  )
+
+  const handleCopyJson = async () => {
+    await navigator.clipboard.writeText(previewJson)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const onDeploy = useCallback(async () => {
+    const address = walletAddress?.trim()
+    if (!address) {
+      toast.error('Connect your admin wallet first.')
+      return
+    }
+    if (!form.assetAddress.trim()) {
+      toast.error('Asset address is required to create a vault.')
+      return
+    }
+
+    const config = buildConfig(form, address)
+    setBusy(true)
+    setLastTxHash(null)
+    setLastVaultAddress(null)
+    try {
+      const res = await fetch('/api/defindex/admin/create-vault', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(config),
+      })
+      if (!res.ok) throw new Error(await readErrorMessage(res))
+
+      const createPayload = (await res.json()) as {
+        xdr?: string
+        simulationResponse?: string
+      }
+      const { xdr } = createPayload
+      if (!xdr) throw new Error('No XDR returned from DeFindex.')
+
+      const submitted = (await signAndSubmit(xdr, address)) as SendTransactionResponse
+      if (submitted?.success === false) {
+        toast.error('Transaction was not successful on-chain.')
+        return
+      }
+
+      const vaultAddress = resolveDeployedVaultAddress(createPayload, submitted)
+      const txHash = submitted?.txHash ?? null
+      if (txHash) setLastTxHash(txHash)
+      if (vaultAddress) setLastVaultAddress(vaultAddress)
+      onDeployed?.({ txHash, vaultAddress })
+
+      toast.success('Vault deployed! Check the next steps below.', {
+        description: vaultAddress
+          ? `Vault: ${vaultAddress.slice(0, 8)}…`
+          : txHash
+            ? `Tx: ${txHash}`
+            : undefined,
+      })
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Vault creation failed.')
+    } finally {
+      setBusy(false)
+    }
+  }, [form, onDeployed, signAndSubmit, walletAddress])
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Create new vault</CardTitle>
+        <CardDescription>
+          Fill in the parameters or use the testnet presets below. Role fields left blank default to your connected wallet.
+          See the{' '}
+          <a
+            href="https://docs.defindex.io/api-integration-guide/creating-a-defindex-vault"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-0.5 underline underline-offset-2"
+          >
+            DeFindex vault guide <ExternalLink className="h-3 w-3" />
+          </a>{' '}
+          for full documentation.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {walletAddress && provider !== 'pollar' && (
+          <div className="flex items-start gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-xs text-blue-800 dark:text-blue-200">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              Signing with <strong>Freighter / Albedo</strong>. If you&apos;re using a Pollar embedded wallet, sign in via the wallet button and it will be used automatically.
+            </span>
+          </div>
+        )}
+
+        <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Info className="h-3.5 w-3.5 shrink-0 text-blue-500" aria-hidden />
+            <p className="text-xs font-semibold text-blue-700 dark:text-blue-400">Testnet quick-fill</p>
+          </div>
+          <p className="mb-3 text-xs text-muted-foreground">
+            On testnet, DeFindex strategies use <strong>BlendUSDC</strong> — a test token from{' '}
+            <a href="https://testnet.blend.capital" target="_blank" rel="noreferrer" className="underline underline-offset-2">
+              testnet.blend.capital
+            </a>
+            , <em>not</em> regular USDC. Get BlendUSDC from their faucet before deploying a USDC vault.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(TESTNET_PRESETS).map(([key, preset]) => (
+              <Button
+                key={key}
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-xs"
+                onClick={() => fillPreset(preset)}
+                disabled={busy}
+              >
+                <Wand2 className="h-3 w-3" aria-hidden />
+                Fill {preset.label} preset
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Vault identity</p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="vault-name">Name</Label>
+              <Input
+                id="vault-name"
+                value={form.name}
+                onChange={set('name')}
+                placeholder="Mercato Vault"
+                disabled={busy}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="vault-symbol">Symbol</Label>
+              <Input
+                id="vault-symbol"
+                value={form.symbol}
+                onChange={set('symbol')}
+                placeholder="mVLT"
+                disabled={busy}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="vault-fee">
+                Fee (bps)
+                <span className="ml-1.5 text-xs text-muted-foreground">
+                  {Number(form.vaultFeeBps) / 100}%
+                </span>
+              </Label>
+              <Input
+                id="vault-fee"
+                type="number"
+                min={0}
+                max={10000}
+                value={form.vaultFeeBps}
+                onChange={set('vaultFeeBps')}
+                placeholder="100"
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex items-center gap-3">
+            <Switch
+              id="vault-upgradable"
+              checked={form.upgradable}
+              onCheckedChange={(v) => setForm((p) => ({ ...p, upgradable: v }))}
+              disabled={busy}
+            />
+            <Label htmlFor="vault-upgradable" className="cursor-pointer">
+              Upgradable contract
+              <span className="ml-1 text-xs text-muted-foreground">(recommended for testnet)</span>
+            </Label>
+          </div>
+        </div>
+
+        <Separator />
+
+        <div>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Asset &amp; strategy</p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="asset-address">
+                Asset contract address <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                id="asset-address"
+                value={form.assetAddress}
+                onChange={set('assetAddress')}
+                placeholder="C… (use preset above for testnet)"
+                className="font-mono text-xs"
+                disabled={busy}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Testnet BlendUSDC: <code className="rounded bg-muted px-0.5">CAQCFVL…RCJU</code>
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="strategy-address">Strategy contract address</Label>
+              <Input
+                id="strategy-address"
+                value={form.strategyAddress}
+                onChange={set('strategyAddress')}
+                placeholder="C… (leave blank for no strategy)"
+                className="font-mono text-xs"
+                disabled={busy}
+              />
+            </div>
+            {form.strategyAddress.trim() && (
+              <div className="space-y-1.5 sm:col-span-2">
+                <Label htmlFor="strategy-name">Strategy label</Label>
+                <Input
+                  id="strategy-name"
+                  value={form.strategyName}
+                  onChange={set('strategyName')}
+                  placeholder="Primary Strategy"
+                  disabled={busy}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+
+        <Separator />
+
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Roles</p>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Leave any field blank to default to your connected wallet address (
+            <span className="font-mono">{walletAddress ? walletAddress.slice(0, 8) + '…' : 'not connected'}</span>).
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {(
+              [
+                { id: 'manager', label: 'Manager', key: 'manager' },
+                { id: 'rebalance-manager', label: 'Rebalance manager', key: 'rebalanceManager' },
+                { id: 'fee-receiver', label: 'Fee receiver', key: 'feeReceiver' },
+                { id: 'emergency-manager', label: 'Emergency manager', key: 'emergencyManager' },
+              ] as const
+            ).map(({ id, label, key }) => (
+              <div key={id} className="space-y-1.5">
+                <Label htmlFor={id}>{label}</Label>
+                <Input
+                  id={id}
+                  value={form[key]}
+                  onChange={set(key)}
+                  placeholder="G… (defaults to your wallet)"
+                  className="font-mono text-xs"
+                  disabled={busy}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-muted/30">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium"
+            onClick={() => setShowAdvanced((p) => !p)}
+          >
+            <span>Preview JSON payload</span>
+            {showAdvanced ? <ChevronUp className="h-4 w-4" aria-hidden /> : <ChevronDown className="h-4 w-4" aria-hidden />}
+          </button>
+          {showAdvanced && (
+            <div className="relative border-t border-border">
+              <pre className="max-h-64 overflow-auto p-4 text-[11px] leading-relaxed text-muted-foreground">
+                {previewJson}
+              </pre>
+              <button
+                type="button"
+                onClick={() => void handleCopyJson()}
+                className="absolute right-3 top-3 rounded-md border border-border bg-background p-1.5 text-muted-foreground hover:text-foreground"
+                title="Copy JSON"
+              >
+                {copied ? <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {lastTxHash && (
+          <VaultDeploymentChecklist
+            txHash={lastTxHash}
+            vaultAddress={lastVaultAddress}
+            managerAddress={walletAddress ?? ''}
+            strategyAddress={form.strategyAddress.trim()}
+          />
+        )}
+
+        <Button
+          className="gap-2"
+          disabled={busy || !form.assetAddress.trim()}
+          onClick={() => void onDeploy()}
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden /> : <Landmark className="h-4 w-4" aria-hidden />}
+          {busy ? 'Deploying vault…' : 'Build XDR & deploy vault'}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/admin/vault-deposit-panel.tsx
+++ b/components/admin/vault-deposit-panel.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { Loader2, Wallet } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { VaultAssetTrustlineCard } from '@/components/admin/vault-asset-trustline-card'
+import { useAdminVaultTransactions } from '@/hooks/use-admin-vault-transactions'
+import { useI18n } from '@/lib/i18n/provider'
+import { displayToRawTokenAmount, getPublicDefindexAssetDecimals } from '@/lib/defindex/client-amounts'
+import {
+  minInitDepositDisplay,
+  VAULT_MIN_INIT_DEPOSIT_RAW,
+} from '@/lib/defindex/vault-activation'
+import type { VaultMonitorPayload } from '@/lib/defindex/vault-monitor'
+import { formatCurrency, formatDecimal } from '@/lib/format'
+import { isMissingTrustlineError } from '@/lib/stellar/vault-asset-trustline'
+
+type VaultDepositPanelProps = {
+  vaultAddress: string
+  monitor: VaultMonitorPayload
+  onSuccess?: () => void
+  variant?: 'card' | 'embedded'
+}
+
+export function VaultDepositPanel({
+  vaultAddress,
+  monitor,
+  onSuccess,
+  variant = 'card',
+}: VaultDepositPanelProps) {
+  const { messages } = useI18n()
+  const m = messages.adminVaultMonitor
+  const { walletAddress, submitAdminXdr } = useAdminVaultTransactions()
+
+  const decimals = getPublicDefindexAssetDecimals()
+  const minDisplay = minInitDepositDisplay(decimals)
+  const assetCount = Math.max(monitor.assets.length, 1)
+  const primaryAsset = monitor.assets[0]
+  const depositDone = monitor.totals.tvlDisplay > 0
+
+  const [depositDisplay, setDepositDisplay] = useState(String(minDisplay))
+  const [busy, setBusy] = useState(false)
+  const [trustlineReady, setTrustlineReady] = useState(false)
+
+  const buildAmountsArray = (rawFirstAsset: number): number[] => {
+    const amounts = new Array(assetCount).fill(0) as number[]
+    amounts[0] = rawFirstAsset
+    return amounts
+  }
+
+  const onDeposit = async () => {
+    const display = Number(depositDisplay)
+    const raw = displayToRawTokenAmount(display, decimals)
+    if (raw < VAULT_MIN_INIT_DEPOSIT_RAW) {
+      toast.error(m.depositTooSmall.replace('{min}', formatDecimal(minDisplay, { maxFractionDigits: 7 })))
+      return
+    }
+
+    setBusy(true)
+    try {
+      const result = await submitAdminXdr('/api/defindex/admin/deposit', {
+        vault: vaultAddress,
+        amounts: buildAmountsArray(raw),
+        invest: false,
+        slippageBps: 100,
+      })
+      if (result?.success === false) {
+        toast.error(m.txFailed)
+        return
+      }
+      toast.success(m.depositSuccess)
+      onSuccess?.()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : m.depositFailed
+      toast.error(isMissingTrustlineError(msg) ? m.trustMissingError : msg)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const content = (
+    <div className="space-y-4">
+      {variant === 'embedded' && (
+        <div>
+          <p className="font-medium">{m.stepDepositTitle}</p>
+          <p className="text-sm text-muted-foreground">{m.stepDepositDesc}</p>
+        </div>
+      )}
+
+      {variant === 'card' && !walletAddress && (
+        <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm text-amber-900 dark:text-amber-200">
+          {m.connectWallet}
+        </p>
+      )}
+
+      {depositDone ? (
+        <p className="text-sm text-emerald-700 dark:text-emerald-400">
+          {m.depositDone.replace('{tvl}', formatCurrency(monitor.totals.tvlDisplay))}
+        </p>
+      ) : (
+        <>
+          {primaryAsset && (
+            <VaultAssetTrustlineCard
+              assetContract={primaryAsset.address}
+              assetSymbol={primaryAsset.symbol}
+              assetName={primaryAsset.name}
+              onTrustlineReady={() => setTrustlineReady(true)}
+            />
+          )}
+          <div className="flex flex-wrap items-end gap-3">
+            <div className="min-w-[10rem] flex-1 space-y-1.5">
+              <Label htmlFor="admin-vault-deposit">{m.depositAmountLabel}</Label>
+              <Input
+                id="admin-vault-deposit"
+                type="number"
+                min={minDisplay}
+                step="any"
+                value={depositDisplay}
+                onChange={(e) => setDepositDisplay(e.target.value)}
+                disabled={busy}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                {m.depositMinHint.replace('{min}', formatDecimal(minDisplay, { maxFractionDigits: 7 }))}
+              </p>
+            </div>
+            <Button
+              type="button"
+              className="gap-2"
+              disabled={busy || !walletAddress || !trustlineReady}
+              onClick={() => void onDeposit()}
+            >
+              {busy ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : (
+                <Wallet className="h-4 w-4" aria-hidden />
+              )}
+              {m.depositCta}
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+
+  if (variant === 'embedded') return content
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{m.stepDepositTitle}</CardTitle>
+        <CardDescription>{m.stepDepositDesc}</CardDescription>
+      </CardHeader>
+      <CardContent>{content}</CardContent>
+    </Card>
+  )
+}

--- a/components/admin/vault-rebalance-panel.tsx
+++ b/components/admin/vault-rebalance-panel.tsx
@@ -1,0 +1,215 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { ArrowRight, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useAdminVaultTransactions } from '@/hooks/use-admin-vault-transactions'
+import { useI18n } from '@/lib/i18n/provider'
+import type { VaultMonitorPayload } from '@/lib/defindex/vault-monitor'
+import { formatCurrency } from '@/lib/format'
+import { isMissingTrustlineError } from '@/lib/stellar/vault-asset-trustline'
+
+type StrategyOption = {
+  assetSymbol: string
+  address: string
+  name: string
+  paused: boolean
+}
+
+type VaultRebalancePanelProps = {
+  vaultAddress: string
+  monitor: VaultMonitorPayload
+  depositDone: boolean
+  onSuccess?: () => void
+  variant?: 'card' | 'embedded'
+}
+
+export function VaultRebalancePanel({
+  vaultAddress,
+  monitor,
+  depositDone,
+  onSuccess,
+  variant = 'card',
+}: VaultRebalancePanelProps) {
+  const { messages } = useI18n()
+  const m = messages.adminVaultMonitor
+  const { walletAddress, submitAdminXdr } = useAdminVaultTransactions()
+
+  const primaryAsset = monitor.assets[0]
+  const rebalanceDone =
+    monitor.totals.investedDisplay > 0 && monitor.totals.idlePercent < 90
+
+  const strategyOptions = useMemo((): StrategyOption[] => {
+    const out: StrategyOption[] = []
+    for (const asset of monitor.assets) {
+      for (const s of asset.strategies) {
+        out.push({
+          assetSymbol: asset.symbol,
+          address: s.address,
+          name: s.name,
+          paused: s.paused,
+        })
+      }
+    }
+    return out
+  }, [monitor.assets])
+
+  const defaultStrategy =
+    strategyOptions.find((s) => !s.paused)?.address ?? strategyOptions[0]?.address ?? ''
+
+  const [strategyAddress, setStrategyAddress] = useState(defaultStrategy)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (defaultStrategy) setStrategyAddress(defaultStrategy)
+  }, [defaultStrategy])
+
+  const idleRaw = useMemo(() => {
+    const raw = Number(primaryAsset?.idleRaw ?? 0)
+    return Number.isFinite(raw) ? Math.floor(raw) : 0
+  }, [primaryAsset?.idleRaw])
+
+  const callerMatchesRebalance =
+    walletAddress &&
+    (walletAddress === monitor.roles.rebalanceManager ||
+      walletAddress === monitor.roles.manager)
+
+  const onRebalance = async () => {
+    if (!strategyAddress) {
+      toast.error(m.noStrategy)
+      return
+    }
+    if (idleRaw <= 0) {
+      toast.error(m.noIdle)
+      return
+    }
+    if (walletAddress && !callerMatchesRebalance) {
+      toast.error(m.callerRoleWarning)
+    }
+
+    setBusy(true)
+    try {
+      const result = await submitAdminXdr('/api/defindex/admin/rebalance', {
+        vault: vaultAddress,
+        instructions: [
+          {
+            type: 'Invest',
+            strategy_address: strategyAddress,
+            amount: idleRaw,
+          },
+        ],
+      })
+      if (result?.success === false) {
+        toast.error(m.txFailed)
+        return
+      }
+      toast.success(m.rebalanceSuccess)
+      onSuccess?.()
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : m.rebalanceFailed
+      toast.error(isMissingTrustlineError(msg) ? m.trustMissingError : msg)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const content = (
+    <div className="space-y-4">
+      {variant === 'embedded' && (
+        <div>
+          <p className="font-medium">{m.stepRebalanceTitle}</p>
+          <p className="text-sm text-muted-foreground">{m.stepRebalanceDesc}</p>
+        </div>
+      )}
+
+      {variant === 'card' && !walletAddress && (
+        <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm text-amber-900 dark:text-amber-200">
+          {m.connectWallet}
+        </p>
+      )}
+
+      {variant === 'card' && walletAddress && (
+        <p className="text-xs text-muted-foreground">
+          {m.signingAs.replace('{address}', `${walletAddress.slice(0, 8)}…${walletAddress.slice(-4)}`)}
+          {!callerMatchesRebalance && (
+            <span className="mt-1 block text-amber-700 dark:text-amber-300">{m.callerRoleHint}</span>
+          )}
+        </p>
+      )}
+
+      {variant === 'embedded' && walletAddress && !callerMatchesRebalance && (
+        <p className="text-xs text-amber-700 dark:text-amber-300">{m.callerRoleHint}</p>
+      )}
+
+      {rebalanceDone ? (
+        <p className="text-sm text-emerald-700 dark:text-emerald-400">{m.rebalanceDone}</p>
+      ) : !depositDone ? (
+        <p className="text-sm text-muted-foreground">{m.rebalanceAfterDeposit}</p>
+      ) : (
+        <div className="space-y-3">
+          {strategyOptions.length > 1 ? (
+            <div className="space-y-1.5">
+              <Label>{m.strategyLabel}</Label>
+              <Select value={strategyAddress} onValueChange={setStrategyAddress}>
+                <SelectTrigger>
+                  <SelectValue placeholder={m.strategyLabel} />
+                </SelectTrigger>
+                <SelectContent>
+                  {strategyOptions.map((s) => (
+                    <SelectItem key={s.address} value={s.address} disabled={s.paused}>
+                      {s.assetSymbol} · {s.name}
+                      {s.paused ? ` (${m.paused})` : ''}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : strategyOptions[0] ? (
+            <p className="text-xs text-muted-foreground">
+              {m.strategyTarget.replace('{name}', strategyOptions[0].name)}
+            </p>
+          ) : null}
+          <p className="text-sm">
+            {m.idleToInvest.replace('{amount}', formatCurrency(primaryAsset?.idleDisplay ?? 0))}
+          </p>
+          <Button
+            type="button"
+            variant="secondary"
+            className="gap-2"
+            disabled={busy || !walletAddress || idleRaw <= 0}
+            onClick={() => void onRebalance()}
+          >
+            {busy ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            )}
+            {m.rebalanceCta}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+
+  if (variant === 'embedded') return content
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{m.stepRebalanceTitle}</CardTitle>
+        <CardDescription>{m.stepRebalanceDesc}</CardDescription>
+      </CardHeader>
+      <CardContent>{content}</CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Summary
- Extract vault creation, deposit, and rebalance admin flows into \VaultCreatePanel\, \VaultDepositPanel\, and \VaultRebalancePanel\, each owning its local form state.
- Keep \AdminDefindexVaultPanel\ as the setup-tab container that composes status UI plus the three panels when a vault address is available.
- Reuse deposit and rebalance panels inside \AdminVaultActivation\ via an embedded variant to avoid duplicated submit logic.

Closes #71

## Test plan
- [x] \pnpm build\ passes locally
- [x] Admin vault setup tab: create vault form still deploys and shows deployment checklist
- [x] Admin vault setup tab: deposit and rebalance panels appear when a vault address is configured or freshly deployed
- [x] Admin vault monitor tab: activation wizard still guides deposit then rebalance
- [x] External wallet (Freighter/Albedo) and Pollar signing paths unchanged

Made with [Cursor](https://cursor.com)