### PR TITLE
refactor: move mock-data to __tests__/fixtures with NODE_ENV guard (#61)

### DIFF
--- a/__tests__/fixtures/mock-deals.ts
+++ b/__tests__/fixtures/mock-deals.ts
@@ -1,4 +1,8 @@
-import { Deal } from './types'
+if (process.env.NODE_ENV === 'production') {
+  throw new Error('[mock-deals] should never be imported in production')
+}
+
+import type { Deal } from '@/lib/types'
 
 export const mockDeals: Deal[] = [
   {

--- a/lib/landing/landing-deal-feed.ts
+++ b/lib/landing/landing-deal-feed.ts
@@ -1,5 +1,4 @@
 import { heroIllustrativeDeals } from '@/lib/hero-illustrative-deals'
-import { mockDeals } from '@/lib/mock-data'
 import { formatCurrency } from '@/lib/format'
 import type { Deal } from '@/lib/types'
 
@@ -121,7 +120,7 @@ export function buildLandingFeed(deals: Deal[]): LandingFeedItem[] {
   const source =
     deals.length > 0
       ? deals.map(dealToFeedItem)
-      : [...mockDeals.map(dealToFeedItem), ...illustrativeToFeed()]
+      : illustrativeToFeed()
 
   const unique = Array.from(new Map(source.map((item) => [item.id, item])).values())
   if (unique.length >= 12) return unique


### PR DESCRIPTION
close #68 
﻿## Context

\lib/mock-data.ts\ contained hardcoded mock \Deal\ objects alongside production code. This posed risks of:

- Mock data silently appearing in production UI
- Unnecessary bundle size bloat
- No \NODE_ENV\ guard preventing production shipping

## Changes

- **Moved** to \__tests__/fixtures/mock-deals.ts\ — restricted to test environments
- **Added** \if (process.env.NODE_ENV === 'production') throw new Error(...)\ guard
- **Deleted** \lib/mock-data.ts\ — no longer lives alongside production code
- **Updated** \lib/landing/landing-deal-feed.ts\ — removed \mockDeals\ import and fallback (uses only illustrative deals when no real data exists)

## Verification

\
g "mock-data"\ in non-test source files returns **zero results**
Bundle analyzer shows no mock data in production chunk
