### PR TITLE
Refactor: Extract shared base abstraction

### DIFF
--- a/lib/anchors/alfredpay/client.ts
+++ b/lib/anchors/alfredpay/client.ts
@@ -37,6 +37,7 @@ import type {
     PaymentInstructions,
 } from '../types';
 import { AnchorError } from '../types';
+import { BaseAnchorClient } from '../base-anchor-client';
 import type {
     AlfredPayConfig,
     AlfredPayCreateCustomerResponse,
@@ -45,7 +46,6 @@ import type {
     AlfredPayOnRampResponse,
     AlfredPayOnRampFlatResponse,
     AlfredPayOffRampResponse,
-    AlfredPayErrorResponse,
     AlfredPayKycRequirementsResponse,
     AlfredPayKycSubmissionRequest,
     AlfredPayKycSubmissionResponse,
@@ -64,7 +64,7 @@ import type {
  * (MXN → USDC) and off-ramp (USDC → MXN) transactions on the Stellar network
  * via Mexico's SPEI payment rail.
  */
-export class AlfredPayClient implements Anchor {
+export class AlfredPayClient extends BaseAnchorClient implements Anchor {
     readonly name = 'alfredpay';
     readonly capabilities: AnchorCapabilities = {
         emailLookup: true,
@@ -77,61 +77,14 @@ export class AlfredPayClient implements Anchor {
 
     /** @param config - API credentials and base URL. */
     constructor(config: AlfredPayConfig) {
-        this.config = config;
-    }
-
-    /**
-     * Send an authenticated JSON request to the AlfredPay API.
-     *
-     * @typeParam T - Expected response body type.
-     * @param method - HTTP method.
-     * @param endpoint - API path appended to {@link AlfredPayConfig.baseUrl}.
-     * @param body - Optional JSON request body.
-     * @returns Parsed response body.
-     * @throws {AnchorError} On non-2xx responses.
-     */
-    private async request<T>(
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-        endpoint: string,
-        body?: unknown,
-    ): Promise<T> {
-        const url = `${this.config.baseUrl}${endpoint}`;
-
-        console.log(`[AlfredPay] ${method} ${url}`, body ? JSON.stringify(body) : '');
-
-        const response = await fetch(url, {
-            method,
-            headers: {
-                'Content-Type': 'application/json',
-                'api-key': this.config.apiKey,
-                'api-secret': this.config.apiSecret,
-            },
-            body: body ? JSON.stringify(body) : undefined,
+        super({
+            baseUrl: config.baseUrl,
+            defaultHeaders: () => ({
+                'api-key': config.apiKey,
+                'api-secret': config.apiSecret,
+            }),
         });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error(`[AlfredPay] Error ${response.status}:`, errorText);
-
-            let errorData: AlfredPayErrorResponse = {
-                error: { code: 'UNKNOWN_ERROR', message: '' },
-            };
-            try {
-                errorData = JSON.parse(errorText) as AlfredPayErrorResponse;
-            } catch {
-                // Not JSON
-            }
-
-            throw new AnchorError(
-                errorData.error?.message || errorText || `AlfredPay API error: ${response.status}`,
-                errorData.error?.code || 'UNKNOWN_ERROR',
-                response.status,
-            );
-        }
-
-        const data = await response.json();
-        console.log(`[AlfredPay] Response:`, JSON.stringify(data));
-        return data as T;
+        this.config = config;
     }
 
     /**
@@ -728,46 +681,17 @@ export class AlfredPayClient implements Anchor {
         file: Blob,
         filename: string,
     ): Promise<AlfredPayKycFileResponse> {
-        const url = `${this.config.baseUrl}/customers/${customerId}/kyc/${submissionId}/files`;
-
-        console.log(`[AlfredPay] POST ${url} (file upload: ${fileType})`);
+        console.log(`[AlfredPay] POST /customers/${customerId}/kyc/${submissionId}/files (file upload: ${fileType})`);
 
         const formData = new FormData();
         formData.append('fileBody', file, filename);
         formData.append('fileType', fileType);
 
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'api-key': this.config.apiKey,
-                'api-secret': this.config.apiSecret,
-            },
-            body: formData,
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error(`[AlfredPay] Error ${response.status}:`, errorText);
-
-            let errorData: AlfredPayErrorResponse = {
-                error: { code: 'UNKNOWN_ERROR', message: '' },
-            };
-            try {
-                errorData = JSON.parse(errorText) as AlfredPayErrorResponse;
-            } catch {
-                // Not JSON
-            }
-
-            throw new AnchorError(
-                errorData.error?.message || errorText || `AlfredPay API error: ${response.status}`,
-                errorData.error?.code || 'UNKNOWN_ERROR',
-                response.status,
-            );
-        }
-
-        const data = await response.json();
-        console.log(`[AlfredPay] Response:`, JSON.stringify(data));
-        return data as AlfredPayKycFileResponse;
+        return this.requestRaw<AlfredPayKycFileResponse>(
+            'POST',
+            `/customers/${customerId}/kyc/${submissionId}/files`,
+            formData,
+        );
     }
 
     // ========== Sandbox-only methods ==========

--- a/lib/anchors/base-anchor-client.ts
+++ b/lib/anchors/base-anchor-client.ts
@@ -1,0 +1,266 @@
+/**
+ * Shared HTTP foundation for anchor integrations.
+ *
+ * Centralises authenticated request construction, retry handling for transient
+ * failures and rate limits, and AnchorError normalisation so concrete clients
+ * can focus on provider-specific endpoint mapping.
+ */
+
+import type { Anchor } from "./types";
+import { AnchorError } from "./types";
+
+export type AnchorHttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+type HeaderFactory = () => HeadersInit;
+
+interface BaseAnchorClientOptions {
+  baseUrl?: string;
+  fetchFn?: typeof fetch;
+  defaultHeaders?: HeaderFactory;
+  maxRetries?: number;
+  retryBaseDelayMs?: number;
+}
+
+interface AnchorRequestOptions {
+  body?: unknown;
+  headers?: HeadersInit;
+  isJson?: boolean;
+  retry?: boolean;
+}
+
+interface NormalizedErrorPayload {
+  message?: string;
+  code?: string;
+}
+
+/** Base class shared by HTTP-backed anchor clients. */
+export abstract class BaseAnchorClient implements Partial<Anchor> {
+  abstract readonly name: string;
+
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly defaultHeaders: HeaderFactory;
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
+
+  protected constructor({
+    baseUrl = "",
+    fetchFn = fetch,
+    defaultHeaders = () => ({}),
+    maxRetries = 2,
+    retryBaseDelayMs = 250,
+  }: BaseAnchorClientOptions = {}) {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+    this.fetchFn = fetchFn;
+    this.defaultHeaders = defaultHeaders;
+    this.maxRetries = maxRetries;
+    this.retryBaseDelayMs = retryBaseDelayMs;
+  }
+
+  /** Build a fetch-compatible function that applies shared retry handling. */
+  protected createRetryingFetch(): typeof fetch {
+    return ((input: RequestInfo | URL, init?: RequestInit) =>
+      this.fetchWithRetry(input, init)) as typeof fetch;
+  }
+
+  /** Send an authenticated JSON request and parse the response as JSON. */
+  protected async request<T>(
+    method: AnchorHttpMethod,
+    endpoint: string,
+    bodyOrOptions?: unknown | AnchorRequestOptions,
+  ): Promise<T> {
+    const options = this.normalizeRequestOptions(bodyOrOptions);
+    const url = this.buildUrl(endpoint);
+    const isJson = options.isJson ?? true;
+    const headers = this.mergeHeaders(
+      isJson ? { "Content-Type": "application/json" } : {},
+      this.defaultHeaders(),
+      options.headers,
+    );
+
+    console.log(
+      `[${this.displayName}] ${method} ${url}`,
+      options.body ? this.safeStringify(options.body) : "",
+    );
+
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        method,
+        headers,
+        body: options.body
+          ? isJson
+            ? JSON.stringify(options.body)
+            : (options.body as BodyInit)
+          : undefined,
+      },
+      options.retry,
+    );
+
+    if (!response.ok) {
+      await this.throwAnchorError(response);
+    }
+
+    const text = await response.text();
+    console.log(`[${this.displayName}] Response:`, text || "(empty)");
+
+    if (!text) {
+      return undefined as T;
+    }
+
+    return JSON.parse(text) as T;
+  }
+
+  /** Send an authenticated non-JSON request, e.g. multipart uploads. */
+  protected async requestRaw<T>(
+    method: AnchorHttpMethod,
+    endpoint: string,
+    body: BodyInit,
+    headers?: HeadersInit,
+  ): Promise<T> {
+    return this.request<T>(method, endpoint, { body, headers, isJson: false });
+  }
+
+  protected buildUrl(endpoint: string): string {
+    if (/^https?:\/\//i.test(endpoint)) {
+      return endpoint;
+    }
+    return `${this.baseUrl}${endpoint}`;
+  }
+
+  protected async fetchWithRetry(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+    retry = true,
+  ): Promise<Response> {
+    const attempts = retry ? this.maxRetries + 1 : 1;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      try {
+        const response = await this.fetchFn(input, init);
+        if (!this.shouldRetryResponse(response) || attempt === attempts - 1) {
+          return response;
+        }
+        await this.delay(this.getRetryDelayMs(response, attempt));
+      } catch (error) {
+        lastError = error;
+        if (attempt === attempts - 1) {
+          break;
+        }
+        await this.delay(this.getBackoffDelayMs(attempt));
+      }
+    }
+
+    throw lastError;
+  }
+
+  protected getErrorCode(payload: unknown): string | undefined {
+    const normalized = this.normalizeErrorPayload(payload);
+    return normalized.code;
+  }
+
+  protected getErrorMessage(payload: unknown): string | undefined {
+    const normalized = this.normalizeErrorPayload(payload);
+    return normalized.message;
+  }
+
+  private async throwAnchorError(response: Response): Promise<never> {
+    const errorText = await response.text();
+    console.error(`[${this.displayName}] Error ${response.status}:`, errorText);
+
+    let payload: unknown;
+    try {
+      payload = errorText ? JSON.parse(errorText) : undefined;
+    } catch {
+      payload = undefined;
+    }
+
+    throw new AnchorError(
+      this.getErrorMessage(payload) ||
+        errorText ||
+        `${this.displayName} API error: ${response.status}`,
+      this.getErrorCode(payload) || "UNKNOWN_ERROR",
+      response.status,
+    );
+  }
+
+  private normalizeErrorPayload(payload: unknown): NormalizedErrorPayload {
+    if (!payload || typeof payload !== "object") return {};
+    const data = payload as Record<string, unknown>;
+    const nested =
+      typeof data.error === "object" && data.error
+        ? (data.error as Record<string, unknown>)
+        : data;
+    return {
+      message: typeof nested.message === "string" ? nested.message : undefined,
+      code: typeof nested.code === "string" ? nested.code : undefined,
+    };
+  }
+
+  private shouldRetryResponse(response: Response): boolean {
+    return (
+      response.status === 429 ||
+      response.status === 408 ||
+      response.status >= 500
+    );
+  }
+
+  private getRetryDelayMs(response: Response, attempt: number): number {
+    const retryAfter = response.headers.get("retry-after");
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds)) return seconds * 1000;
+      const dateMs = Date.parse(retryAfter);
+      if (Number.isFinite(dateMs)) return Math.max(0, dateMs - Date.now());
+    }
+    return this.getBackoffDelayMs(attempt);
+  }
+
+  private getBackoffDelayMs(attempt: number): number {
+    return this.retryBaseDelayMs * 2 ** attempt;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private normalizeRequestOptions(
+    bodyOrOptions?: unknown | AnchorRequestOptions,
+  ): AnchorRequestOptions {
+    if (
+      bodyOrOptions &&
+      typeof bodyOrOptions === "object" &&
+      ("body" in bodyOrOptions ||
+        "headers" in bodyOrOptions ||
+        "isJson" in bodyOrOptions ||
+        "retry" in bodyOrOptions)
+    ) {
+      return bodyOrOptions as AnchorRequestOptions;
+    }
+    return { body: bodyOrOptions };
+  }
+
+  private mergeHeaders(
+    ...headersList: Array<HeadersInit | undefined>
+  ): Headers {
+    const merged = new Headers();
+    for (const headers of headersList) {
+      if (!headers) continue;
+      new Headers(headers).forEach((value, key) => merged.set(key, value));
+    }
+    return merged;
+  }
+
+  private safeStringify(value: unknown): string {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  private get displayName(): string {
+    return this.name.charAt(0).toUpperCase() + this.name.slice(1);
+  }
+}

--- a/lib/anchors/blindpay/client.ts
+++ b/lib/anchors/blindpay/client.ts
@@ -31,6 +31,7 @@ import type {
     TransactionStatus,
 } from '../types';
 import { AnchorError } from '../types';
+import { BaseAnchorClient } from '../base-anchor-client';
 import type {
     BlindPayConfig,
     BlindPayTosResponse,
@@ -42,7 +43,6 @@ import type {
     BlindPayPayoutAuthorizeResponse,
     BlindPayPayoutResponse,
     BlindPayPayinResponse,
-    BlindPayErrorResponse,
     BlindPayPayoutStatus,
     BlindPayPayinStatus,
     BlindPayReceiverStatus,
@@ -57,7 +57,7 @@ import type {
  * payin quotes, on-ramp (MXN → USDC) and off-ramp (USDC → MXN)
  * transactions on the Stellar network via Mexico's SPEI payment rail.
  */
-export class BlindPayClient implements Anchor {
+export class BlindPayClient extends BaseAnchorClient implements Anchor {
     readonly name = 'blindpay';
     readonly capabilities: AnchorCapabilities = {
         kycUrl: true,
@@ -75,6 +75,10 @@ export class BlindPayClient implements Anchor {
     private readonly network: string;
 
     constructor(config: BlindPayConfig) {
+        super({
+            baseUrl: config.baseUrl,
+            defaultHeaders: () => ({ Authorization: `Bearer ${config.apiKey}` }),
+        });
         this.config = config;
         this.network = config.network || 'stellar_testnet';
     }
@@ -190,57 +194,6 @@ export class BlindPayClient implements Anchor {
             createdAt: response.created_at,
             updatedAt: response.updated_at,
         };
-    }
-
-    /**
-     * Send an authenticated JSON request to the BlindPay API.
-     *
-     * @typeParam T - Expected response body type.
-     * @param method - HTTP method.
-     * @param endpoint - API path appended to base URL.
-     * @param body - Optional JSON request body.
-     * @returns Parsed response body.
-     * @throws {AnchorError} On non-2xx responses.
-     */
-    private async request<T>(
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-        endpoint: string,
-        body?: unknown,
-    ): Promise<T> {
-        const url = `${this.config.baseUrl}${endpoint}`;
-
-        console.log(`[BlindPay] ${method} ${url}`, body ? JSON.stringify(body) : '');
-
-        const response = await fetch(url, {
-            method,
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${this.config.apiKey}`,
-            },
-            body: body ? JSON.stringify(body) : undefined,
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error(`[BlindPay] Error ${response.status}:`, errorText);
-
-            let errorData: BlindPayErrorResponse = {};
-            try {
-                errorData = JSON.parse(errorText) as BlindPayErrorResponse;
-            } catch {
-                // Not JSON
-            }
-
-            throw new AnchorError(
-                errorData.error?.message || errorText || `BlindPay API error: ${response.status}`,
-                errorData.error?.code || 'UNKNOWN_ERROR',
-                response.status,
-            );
-        }
-
-        const data = await response.json();
-        console.log(`[BlindPay] Response:`, JSON.stringify(data));
-        return data as T;
     }
 
     // =========================================================================

--- a/lib/anchors/etherfuse/client.ts
+++ b/lib/anchors/etherfuse/client.ts
@@ -36,6 +36,7 @@ import type {
     TransactionStatus,
 } from '../types';
 import { AnchorError } from '../types';
+import { BaseAnchorClient } from '../base-anchor-client';
 import type {
     EtherfuseConfig,
     EtherfuseOnboardingResponse,
@@ -48,7 +49,6 @@ import type {
     EtherfuseBankAccountResponse,
     EtherfuseBankAccountListResponse,
     EtherfuseAssetsResponse,
-    EtherfuseErrorResponse,
     EtherfuseOrderStatus,
     EtherfuseKycIdentityRequest,
     EtherfuseKycDocumentRequest,
@@ -61,7 +61,7 @@ import type {
  * (MXN → CETES) and off-ramp (CETES → MXN) transactions on the Stellar
  * network via Mexico's SPEI payment rail.
  */
-export class EtherfuseClient implements Anchor {
+export class EtherfuseClient extends BaseAnchorClient implements Anchor {
     readonly name = 'etherfuse';
     readonly capabilities: AnchorCapabilities = {
         kycUrl: true,
@@ -76,6 +76,10 @@ export class EtherfuseClient implements Anchor {
 
     /** @param config - API key, base URL, and optional defaults. */
     constructor(config: EtherfuseConfig) {
+        super({
+            baseUrl: config.baseUrl,
+            defaultHeaders: () => ({ Authorization: config.apiKey }),
+        });
         this.config = config;
         this.blockchain = config.defaultBlockchain || 'stellar';
     }
@@ -106,64 +110,6 @@ export class EtherfuseClient implements Anchor {
             identifiers.get(fromCurrency) ?? fromCurrency,
             identifiers.get(toCurrency) ?? toCurrency,
         ];
-    }
-
-    /**
-     * Send an authenticated JSON request to the Etherfuse API.
-     *
-     * @typeParam T - Expected response body type.
-     * @param method - HTTP method.
-     * @param endpoint - API path appended to {@link EtherfuseConfig.baseUrl}.
-     * @param body - Optional JSON request body.
-     * @returns Parsed response body.
-     * @throws {AnchorError} On non-2xx responses.
-     */
-    private async request<T>(
-        method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-        endpoint: string,
-        body?: unknown,
-    ): Promise<T> {
-        const url = `${this.config.baseUrl}${endpoint}`;
-
-        console.log(`[Etherfuse] ${method} ${url}`, body ? JSON.stringify(body) : '');
-
-        const response = await fetch(url, {
-            method,
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: this.config.apiKey,
-            },
-            body: body ? JSON.stringify(body) : undefined,
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error(`[Etherfuse] Error ${response.status}:`, errorText);
-
-            let errorData: EtherfuseErrorResponse = {
-                error: { code: 'UNKNOWN_ERROR', message: '' },
-            };
-            try {
-                errorData = JSON.parse(errorText) as EtherfuseErrorResponse;
-            } catch {
-                // Not JSON
-            }
-
-            throw new AnchorError(
-                errorData.error?.message || errorText || `Etherfuse API error: ${response.status}`,
-                errorData.error?.code || 'UNKNOWN_ERROR',
-                response.status,
-            );
-        }
-
-        const text = await response.text();
-        console.log(`[Etherfuse] Response:`, text || '(empty)');
-
-        if (!text) {
-            return undefined as T;
-        }
-
-        return JSON.parse(text) as T;
     }
 
     // =========================================================================
@@ -798,27 +744,7 @@ export class EtherfuseClient implements Anchor {
      */
     async acceptAgreements(presignedUrl: string): Promise<unknown> {
         console.log(`[Etherfuse] POST ${presignedUrl} (accept agreements)`);
-
-        const response = await fetch(presignedUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: this.config.apiKey,
-            },
-            body: JSON.stringify({ acceptAll: true }),
-        });
-
-        if (!response.ok) {
-            const errorText = await response.text();
-            console.error(`[Etherfuse] Error ${response.status}:`, errorText);
-            throw new AnchorError(
-                errorText || `Etherfuse API error: ${response.status}`,
-                'AGREEMENT_ERROR',
-                response.status,
-            );
-        }
-
-        return response.json();
+        return this.request('POST', presignedUrl, { acceptAll: true });
     }
 
     /**
@@ -830,10 +756,7 @@ export class EtherfuseClient implements Anchor {
      * @returns The HTTP status code from the Etherfuse API (200, 400, or 404).
      */
     async simulateFiatReceived(orderId: string): Promise<number> {
-        const url = `${this.config.baseUrl}/ramp/order/fiat_received`;
-        console.log(`[Etherfuse] POST ${url}`, JSON.stringify({ orderId }));
-
-        const response = await fetch(url, {
+        const response = await this.fetchWithRetry(this.buildUrl('/ramp/order/fiat_received'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/lib/anchors/testanchor/client.ts
+++ b/lib/anchors/testanchor/client.ts
@@ -25,6 +25,7 @@ import {
 } from '../sep/sep10';
 
 import { sep6, sep12, sep24, sep31, sep38 } from '../sep';
+import { BaseAnchorClient } from '../base-anchor-client';
 
 import type {
     Sep6Info,
@@ -65,18 +66,21 @@ const TESTNET_PASSPHRASE = 'Test SDF Network ; September 2015';
  * Provides a unified interface for interacting with the Stellar test anchor.
  * Handles authentication, token management, and all supported SEP operations.
  */
-export class TestAnchorClient {
+export class TestAnchorClient extends BaseAnchorClient {
     private domain: string;
     private networkPassphrase: string;
     private toml: StellarTomlRecord | null = null;
     private token: string | null = null;
     private account: string | null = null;
-    private fetchFn: typeof fetch;
+    private sepFetchFn: typeof fetch;
+
+    readonly name = 'testanchor';
 
     constructor(config: TestAnchorConfig = {}, fetchFn: typeof fetch = fetch) {
+        super({ baseUrl: `https://${config.domain || DEFAULT_DOMAIN}`, fetchFn });
         this.domain = config.domain || DEFAULT_DOMAIN;
         this.networkPassphrase = config.networkPassphrase || TESTNET_PASSPHRASE;
-        this.fetchFn = fetchFn;
+        this.sepFetchFn = this.createRetryingFetch();
     }
 
     // ===========================================================================
@@ -154,7 +158,7 @@ export class TestAnchorClient {
             account,
             signer,
             { validateChallenge: !!signingKey },
-            this.fetchFn,
+            this.sepFetchFn,
         );
 
         this.account = account;
@@ -217,7 +221,7 @@ export class TestAnchorClient {
         const kycServer = getSep12Endpoint(toml);
         if (!kycServer) throw new Error('Anchor does not support SEP-12');
 
-        return sep12.getCustomer(kycServer, this.requireAuth(), { type }, this.fetchFn);
+        return sep12.getCustomer(kycServer, this.requireAuth(), { type }, this.sepFetchFn);
     }
 
     /**
@@ -228,7 +232,7 @@ export class TestAnchorClient {
         const kycServer = getSep12Endpoint(toml);
         if (!kycServer) throw new Error('Anchor does not support SEP-12');
 
-        return sep12.putCustomer(kycServer, this.requireAuth(), data, this.fetchFn);
+        return sep12.putCustomer(kycServer, this.requireAuth(), data, this.sepFetchFn);
     }
 
     /**
@@ -239,7 +243,7 @@ export class TestAnchorClient {
         const kycServer = getSep12Endpoint(toml);
         if (!kycServer) throw new Error('Anchor does not support SEP-12');
 
-        return sep12.deleteCustomer(kycServer, this.requireAuth(), {}, this.fetchFn);
+        return sep12.deleteCustomer(kycServer, this.requireAuth(), {}, this.sepFetchFn);
     }
 
     // ===========================================================================
@@ -254,7 +258,7 @@ export class TestAnchorClient {
         const quoteServer = getSep38Endpoint(toml);
         if (!quoteServer) throw new Error('Anchor does not support SEP-38');
 
-        return sep38.getInfo(quoteServer, this.fetchFn);
+        return sep38.getInfo(quoteServer, this.sepFetchFn);
     }
 
     /**
@@ -265,7 +269,7 @@ export class TestAnchorClient {
         const quoteServer = getSep38Endpoint(toml);
         if (!quoteServer) throw new Error('Anchor does not support SEP-38');
 
-        return sep38.getPrice(quoteServer, request, this.fetchFn);
+        return sep38.getPrice(quoteServer, request, this.sepFetchFn);
     }
 
     /**
@@ -276,7 +280,7 @@ export class TestAnchorClient {
         const quoteServer = getSep38Endpoint(toml);
         if (!quoteServer) throw new Error('Anchor does not support SEP-38');
 
-        return sep38.postQuote(quoteServer, this.requireAuth(), request, this.fetchFn);
+        return sep38.postQuote(quoteServer, this.requireAuth(), request, this.sepFetchFn);
     }
 
     /**
@@ -287,7 +291,7 @@ export class TestAnchorClient {
         const quoteServer = getSep38Endpoint(toml);
         if (!quoteServer) throw new Error('Anchor does not support SEP-38');
 
-        return sep38.getQuote(quoteServer, this.requireAuth(), quoteId, this.fetchFn);
+        return sep38.getQuote(quoteServer, this.requireAuth(), quoteId, this.sepFetchFn);
     }
 
     // ===========================================================================
@@ -302,7 +306,7 @@ export class TestAnchorClient {
         const transferServer = getSep6Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-6');
 
-        return sep6.getInfo(transferServer, this.fetchFn);
+        return sep6.getInfo(transferServer, this.sepFetchFn);
     }
 
     /**
@@ -313,7 +317,7 @@ export class TestAnchorClient {
         const transferServer = getSep6Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-6');
 
-        return sep6.deposit(transferServer, this.requireAuth(), request, this.fetchFn);
+        return sep6.deposit(transferServer, this.requireAuth(), request, this.sepFetchFn);
     }
 
     /**
@@ -324,7 +328,7 @@ export class TestAnchorClient {
         const transferServer = getSep6Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-6');
 
-        return sep6.withdraw(transferServer, this.requireAuth(), request, this.fetchFn);
+        return sep6.withdraw(transferServer, this.requireAuth(), request, this.sepFetchFn);
     }
 
     /**
@@ -335,7 +339,7 @@ export class TestAnchorClient {
         const transferServer = getSep6Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-6');
 
-        return sep6.getTransaction(transferServer, this.requireAuth(), transactionId, this.fetchFn);
+        return sep6.getTransaction(transferServer, this.requireAuth(), transactionId, this.sepFetchFn);
     }
 
     /**
@@ -350,7 +354,7 @@ export class TestAnchorClient {
             transferServer,
             this.requireAuth(),
             { asset_code: assetCode, limit },
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -366,7 +370,7 @@ export class TestAnchorClient {
         const transferServer = getSep24Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-24');
 
-        return sep24.getInfo(transferServer, this.fetchFn);
+        return sep24.getInfo(transferServer, this.sepFetchFn);
     }
 
     /**
@@ -378,7 +382,7 @@ export class TestAnchorClient {
         const transferServer = getSep24Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-24');
 
-        return sep24.deposit(transferServer, this.requireAuth(), request, this.fetchFn);
+        return sep24.deposit(transferServer, this.requireAuth(), request, this.sepFetchFn);
     }
 
     /**
@@ -390,7 +394,7 @@ export class TestAnchorClient {
         const transferServer = getSep24Endpoint(toml);
         if (!transferServer) throw new Error('Anchor does not support SEP-24');
 
-        return sep24.withdraw(transferServer, this.requireAuth(), request, this.fetchFn);
+        return sep24.withdraw(transferServer, this.requireAuth(), request, this.sepFetchFn);
     }
 
     /**
@@ -405,7 +409,7 @@ export class TestAnchorClient {
             transferServer,
             this.requireAuth(),
             transactionId,
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -421,7 +425,7 @@ export class TestAnchorClient {
             transferServer,
             this.requireAuth(),
             { asset_code: assetCode, limit },
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -441,7 +445,7 @@ export class TestAnchorClient {
             this.requireAuth(),
             transactionId,
             { onStatusChange },
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -457,7 +461,7 @@ export class TestAnchorClient {
         const directPaymentServer = getSep31Endpoint(toml);
         if (!directPaymentServer) throw new Error('Anchor does not support SEP-31');
 
-        return sep31.getInfo(directPaymentServer, this.fetchFn);
+        return sep31.getInfo(directPaymentServer, this.sepFetchFn);
     }
 
     /**
@@ -474,7 +478,7 @@ export class TestAnchorClient {
             directPaymentServer,
             this.requireAuth(),
             request,
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -490,7 +494,7 @@ export class TestAnchorClient {
             directPaymentServer,
             this.requireAuth(),
             transactionId,
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -510,7 +514,7 @@ export class TestAnchorClient {
             this.requireAuth(),
             transactionId,
             fields,
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 
@@ -530,7 +534,7 @@ export class TestAnchorClient {
             this.requireAuth(),
             transactionId,
             { onStatusChange },
-            this.fetchFn,
+            this.sepFetchFn,
         );
     }
 }


### PR DESCRIPTION
Motivation
Reduce large duplicated HTTP/SE P-10/rate-limit logic present across multiple anchor clients by centralising a shared HTTP abstraction.
Ensure consistent error normalization and retry behaviour for 429/408/5xx responses across all anchors.
Make concrete anchor clients smaller so they only contain provider-specific endpoint mapping and mapping helpers.
Description
Add lib/anchors/base-anchor-client.ts which provides request/requestRaw, fetchWithRetry, retry/backoff and rate-limit handling, error payload normalization, header merging, and a createRetryingFetch helper for SEP modules.
Refactor AlfredPayClient, BlindPayClient, and EtherfuseClient to extend BaseAnchorClient and inject provider auth headers via the base defaultHeaders option so duplicated request helpers were removed.
Route multipart KYC uploads in AlfredPay to requestRaw, and route presigned agreement and sandbox calls in Etherfuse through the shared request/retry utilities to reuse error handling and retries.
Update TestAnchorClient to extend BaseAnchorClient and use a retry-wrapped fetch (createRetryingFetch) for SEP module calls so SEP requests benefit from shared retry logic.
Testing
Ran git diff --check which produced no whitespace/merge conflicts related warnings and completed successfully.
Ran npx tsc --noEmit --pretty false, which surfaced existing unrelated TypeScript errors outside the modified anchor files and thus the full build fails, but the changes in lib/anchors and base-anchor-client did not produce type errors when filtered.
Ran npm run lint which failed in this environment because next lint resolved an invalid project directory, so linting could not be fully verified here.
Closes https://github.com/mercato-supply-chain/mercato-dapp/issues/63