### PR TITLE
fix: improve landing anchor scroll and move partners strip

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,7 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    scroll-padding-top: 6rem;
     overflow-x: hidden;
   }
 
@@ -231,7 +232,7 @@
 
 /* Landing in-page nav targets (sticky header offset) */
 .landing-section-anchor {
-  scroll-margin-top: 5.5rem;
+  scroll-margin-top: 6rem;
 }
 
 /* ─── Hero ambient glow animation ──────────────────────── */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { LandingLiveDeals } from '@/components/landing/landing-live-deals'
 import { LandingFaq } from '@/components/landing/landing-faq'
 import { LandingFooter } from '@/components/landing/landing-footer'
 import { LandingHashScroll } from '@/components/landing/landing-hash-scroll'
+import { LandingPartnersStrip } from '@/components/landing/landing-page-intro'
 import { JsonLd } from '@/components/seo/json-ld'
 import { getLandingPlatformStats } from '@/lib/landing/get-platform-stats'
 
@@ -66,6 +67,8 @@ export default async function HomePage() {
       </section>
 
       <LandingFaq />
+
+      <LandingPartnersStrip />
 
       <LandingFooter />
     </div>

--- a/components/landing/landing-hero.tsx
+++ b/components/landing/landing-hero.tsx
@@ -2,7 +2,6 @@
 
 import { HeroHowItWorksSteps } from '@/components/landing/hero-how-it-works-steps'
 import { HeroStatsBar } from '@/components/landing/hero-stats-bar'
-import { LandingPartnersStrip } from '@/components/landing/landing-page-intro'
 import type { LandingPlatformStats } from '@/lib/landing/platform-stats'
 import { useI18n } from '@/lib/i18n/provider'
 import { BadgeCheck, Eye, ShieldCheck } from 'lucide-react'
@@ -85,10 +84,6 @@ export function LandingHero({ stats }: LandingHeroProps) {
         className="hero-ref-bases-steps landing-section-anchor relative z-10 w-full bg-background pb-8 pt-0 md:pb-10 dark:bg-[hsl(0_0%_4%)]"
       >
         <HeroHowItWorksSteps />
-      </div>
-
-      <div className="relative z-10 border-t border-border/50 bg-background dark:border-white/[0.06] dark:bg-[hsl(0_0%_3%)]">
-        <LandingPartnersStrip variant="hero" />
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- add global scroll padding and align landing section scroll margin with the fixed header
- remove the partners strip from the hero section
- render the partners strip near the end of the homepage before the footer

Closes #86

## Validation
- Confirmed #86 had no active duplicate PR before this submission.
- Verified the branch changes `app/globals.css`, `components/landing/landing-hero.tsx`, and `app/page.tsx`.
- Local app execution was not available in this browser-only environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll behavior for anchor links to prevent content from being hidden behind the fixed header.

* **Style**
  * Repositioned partners section from hero to a dedicated area on the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->