### PR TITLE
fix: rename useFinancingOptions to resolve hook violation (closes #53)

### DIFF
--- a/components/landing/landing-rate-comparison.tsx
+++ b/components/landing/landing-rate-comparison.tsx
@@ -36,7 +36,7 @@ type FinancingOption = {
 
 const RATE_SCALE_MAX = 120
 
-function useFinancingOptions(t: (key: string) => string): FinancingOption[] {
+function getFinancingOptions(t: (key: string) => string): FinancingOption[] {
   return [
     {
       id: 'mercato',
@@ -161,7 +161,7 @@ function AccessPill({ level, t }: { level: AccessLevel; t: (key: string) => stri
 export function LandingRateComparison() {
   const { t } = useI18n()
   const { ref, visible } = useReveal<HTMLElement>(0.08)
-  const financingOptions = React.useMemo(() => useFinancingOptions(t), [t])
+  const financingOptions = React.useMemo(() => getFinancingOptions(t), [t])
   
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true, align: 'center' }, [Autoplay({ delay: 5000 })])
   const [selectedIndex, setSelectedIndex] = React.useState(0)


### PR DESCRIPTION
## Summary
Resolves #53 by fixing a Rules of Hooks violation in the landing rate comparison component.

## Changes
- Renamed the pure utility function `useFinancingOptions` to `getFinancingOptions` since it doesn't consume any React hooks.
- Updated the call site to keep the `React.useMemo` wrapper validly:
  ```typescript
  const financingOptions = React.useMemo(() => getFinancingOptions(t), [t])


Closes #53 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization to improve application maintainability with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->