### PR TITLE
Fix/navigation scroll offset issue 86

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -231,7 +231,7 @@
 
 /* Landing in-page nav targets (sticky header offset) */
 .landing-section-anchor {
-  scroll-margin-top: 5.5rem;
+  scroll-margin-top: 6rem;
 }
 
 /* ─── Hero ambient glow animation ──────────────────────── */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { LandingRoles } from '@/components/landing/landing-roles'
 import { LandingRateComparison } from '@/components/landing/landing-rate-comparison'
 import { LandingLiveDeals } from '@/components/landing/landing-live-deals'
 import { LandingFaq } from '@/components/landing/landing-faq'
+import { LandingPartnersStrip } from '@/components/landing/landing-page-intro'
 import { LandingFooter } from '@/components/landing/landing-footer'
 import { LandingHashScroll } from '@/components/landing/landing-hash-scroll'
 import { JsonLd } from '@/components/seo/json-ld'
@@ -66,6 +67,8 @@ export default async function HomePage() {
       </section>
 
       <LandingFaq />
+
+      <LandingPartnersStrip />
 
       <LandingFooter />
     </div>

--- a/components/landing/landing-footer.tsx
+++ b/components/landing/landing-footer.tsx
@@ -15,6 +15,12 @@ export function LandingFooter() {
   const pathname = usePathname()
   const onHome = pathname === '/'
 
+  const handleHashClick = (href: string) => {
+    if (onHome && href.startsWith('#') && window.location.hash === href) {
+      document.getElementById(href.slice(1))?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+  }
+
   const footerLinks = {
     [t('landing.footer.exploreTitle')]: PUBLIC_NAV_LINKS.map(({ sectionId, labelKey }) => ({
       label: t(labelKey),
@@ -60,6 +66,7 @@ export function LandingFooter() {
                     <Link
                       href={link.href}
                       className="group inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-brand-mid dark:hover:text-brand-light"
+                      onClick={() => handleHashClick(link.href)}
                     >
                       {link.label}
                       <ArrowUpRight

--- a/components/landing/landing-hash-scroll.tsx
+++ b/components/landing/landing-hash-scroll.tsx
@@ -1,26 +1,49 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useCallback } from 'react'
 import { usePathname } from 'next/navigation'
 
-/** Scroll to `#section` after navigating to the homepage with a hash. */
+const NAV_HEIGHT = 64
+
+function scrollToId(id: string) {
+  const el = document.getElementById(id)
+  if (!el) return
+
+  let attempts = 0
+  const maxAttempts = 10
+  const tryScroll = () => {
+    attempts++
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    // Check if scroll reached the target (within a tolerance for the nav offset).
+    // If the body is still scroll-locked (e.g. mobile sheet closing) the element
+    // stays far below the viewport — retry after the lock releases.
+    requestAnimationFrame(() => {
+      const top = el.getBoundingClientRect().top
+      if (top > NAV_HEIGHT * 2.5 && attempts < maxAttempts) {
+        setTimeout(tryScroll, 80)
+      }
+    })
+  }
+  // Initial delay lets a closing overlay or page render settle.
+  setTimeout(tryScroll, 50)
+}
+
+/** Scroll to `#section` on the homepage after hash changes or cross-page navigation. */
 export function LandingHashScroll() {
   const pathname = usePathname()
 
-  useEffect(() => {
-    if (pathname !== '/') return
+  const scrollToHash = useCallback(() => {
     const hash = window.location.hash
     if (!hash) return
+    scrollToId(hash.replace('#', ''))
+  }, [])
 
-    const id = hash.replace('#', '')
-    const scrollToTarget = () => {
-      document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }
-
-    requestAnimationFrame(() => {
-      requestAnimationFrame(scrollToTarget)
-    })
-  }, [pathname])
+  useEffect(() => {
+    if (pathname !== '/') return
+    scrollToHash()
+    window.addEventListener('hashchange', scrollToHash)
+    return () => window.removeEventListener('hashchange', scrollToHash)
+  }, [pathname, scrollToHash])
 
   return null
 }

--- a/components/landing/landing-hero.tsx
+++ b/components/landing/landing-hero.tsx
@@ -2,7 +2,6 @@
 
 import { HeroHowItWorksSteps } from '@/components/landing/hero-how-it-works-steps'
 import { HeroStatsBar } from '@/components/landing/hero-stats-bar'
-import { LandingPartnersStrip } from '@/components/landing/landing-page-intro'
 import type { LandingPlatformStats } from '@/lib/landing/platform-stats'
 import { useI18n } from '@/lib/i18n/provider'
 import { BadgeCheck, Eye, ShieldCheck } from 'lucide-react'
@@ -85,10 +84,6 @@ export function LandingHero({ stats }: LandingHeroProps) {
         className="hero-ref-bases-steps landing-section-anchor relative z-10 w-full bg-background pb-8 pt-0 md:pb-10 dark:bg-[hsl(0_0%_4%)]"
       >
         <HeroHowItWorksSteps />
-      </div>
-
-      <div className="relative z-10 border-t border-border/50 bg-background dark:border-white/[0.06] dark:bg-[hsl(0_0%_3%)]">
-        <LandingPartnersStrip variant="hero" />
       </div>
     </section>
   )

--- a/components/navigation/public-nav-links.tsx
+++ b/components/navigation/public-nav-links.tsx
@@ -49,12 +49,19 @@ export function PublicNavLinks({ variant, onNavigate }: PublicNavLinksProps) {
         : 'text-muted-foreground hover:text-foreground',
     )
 
+  const handleSectionClick = (sectionId: string) => {
+    if (onHome && window.location.hash === `#${sectionId}`) {
+      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }
+    onNavigate?.()
+  }
+
   const sectionItems = PUBLIC_NAV_LINKS.map(({ sectionId, labelKey }) => (
     <Link
       key={sectionId}
       href={landingSectionHref(sectionId, onHome)}
       className={linkClass(sectionId)}
-      onClick={onNavigate}
+      onClick={() => handleSectionClick(sectionId)}
     >
       {t(labelKey)}
     </Link>


### PR DESCRIPTION
## Summary
- Fixed anchor scroll offset so the sticky header no longer covers target sections when clicking nav links
- Relocated "Built with the Stellar ecosystem" section to the last part of the main page (just before the footer)
- (Additional) Fixed repeated clicks on the same nav section link not scrolling back to the section — not mentioned in the issue, detected during manual testing

Closes #86

## Test plan
- [ ] Click each nav link and verify the section heading is fully visible below the header
- [ ] Test on mobile: open nav sheet, tap a section, verify smooth scroll with correct offset
- [ ] Verify "Built with the Stellar ecosystem" appears between FAQ and footer
- [ ] Click the same section link twice in a row — should scroll back both times
- [ ] Test from footer links as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dedicated partners section to the landing page for better visibility.
  * Enhanced in-page navigation with improved smooth scrolling behavior when clicking section links on the homepage.

* **Style**
  * Adjusted scroll offset for better alignment with sticky navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->