### PR TITLE
fix: validate /api/catalog response is array before assignment in use…

### DIFF
--- a/hooks/use-create-deal-init.ts
+++ b/hooks/use-create-deal-init.ts
@@ -18,8 +18,10 @@ export function useCreateDealInit() {
       try {
         const res = await fetch('/api/catalog')
         if (res.ok) {
-          const data = await res.json()
-          products = data as SupplierProductRow[]
+          const data: unknown = await res.json()
+          if (Array.isArray(data)) {
+            products = data as SupplierProductRow[]
+          }
         }
       } catch {
         // fallback: load via client (requires RLS policy supplier_products_select_all)


### PR DESCRIPTION
## Problem
The response from `/api/catalog` was cast directly to `SupplierProductRow[]`
without runtime validation. A non-array response (error envelope, plain object)
would silently skip the Supabase fallback and break downstream `.map()`/`.filter()` calls.

## Fix
- Type `res.json()` result as `unknown` (no implicit `any`)
- Guard with `Array.isArray(data)` before assigning to `products`
- Non-array responses leave `products = []`, correctly triggering the Supabase fallback

## Files Changed
- `hooks/use-create-deal-init.ts`

- Closes #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved catalog data handling during deal creation so product lists only load when the API response is a valid array.
  * Reduced the risk of showing incorrect or broken product data when the server returns an unexpected response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->