### PR TITLE
fix: reuse scrollToId retry logic for same-hash nav clicks

### DIFF
--- a/components/landing/landing-footer.tsx
+++ b/components/landing/landing-footer.tsx
@@ -9,6 +9,7 @@ import {
   PUBLIC_NAV_LINKS,
 } from '@/lib/navigation/landing-nav'
 import { ArrowUpRight } from 'lucide-react'
+import { scrollToId } from '@/components/landing/landing-hash-scroll'
 
 export function LandingFooter() {
   const { t } = useI18n()
@@ -17,7 +18,7 @@ export function LandingFooter() {
 
   const handleHashClick = (href: string) => {
     if (onHome && href.startsWith('#') && window.location.hash === href) {
-      document.getElementById(href.slice(1))?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      scrollToId(href.slice(1))
     }
   }
 

--- a/components/landing/landing-hash-scroll.tsx
+++ b/components/landing/landing-hash-scroll.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation'
 
 const NAV_HEIGHT = 64
 
-function scrollToId(id: string) {
+export function scrollToId(id: string) {
   const el = document.getElementById(id)
   if (!el) return
 

--- a/components/navigation/public-nav-links.tsx
+++ b/components/navigation/public-nav-links.tsx
@@ -11,6 +11,7 @@ import {
   PUBLIC_PAGE_LINKS,
   type LandingSectionId,
 } from '@/lib/navigation/landing-nav'
+import { scrollToId } from '@/components/landing/landing-hash-scroll'
 
 interface PublicNavLinksProps {
   variant: 'desktop' | 'mobile'
@@ -51,7 +52,7 @@ export function PublicNavLinks({ variant, onNavigate }: PublicNavLinksProps) {
 
   const handleSectionClick = (sectionId: string) => {
     if (onHome && window.location.hash === `#${sectionId}`) {
-      document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      scrollToId(sectionId)
     }
     onNavigate?.()
   }


### PR DESCRIPTION
 ## Summary

  - Export `scrollToId` from `landing-hash-scroll.tsx` (was private)
  - Replace bare `scrollIntoView` in `PublicNavLinks.handleSectionClick` with `scrollToId`
  - Replace bare `scrollIntoView` in `LandingFooter.handleHashClick` with `scrollToId`

  ## Problem

  When a user clicked a nav link already matching the active hash, `handleSectionClick` called `scrollIntoView` once, immediately. On mobile, if the sheet's scroll-lock had not
  fully released at that moment, the scroll was silently dropped.

  `LandingHashScroll` already had `scrollToId` with retry logic (up to 10 attempts, 80 ms apart, 50 ms initial delay) that handles this case — but the same-hash click path in
  `PublicNavLinks` and `LandingFooter` did not reuse it.

  ## Fix

  Exported `scrollToId` and called it in both components. No behavior change on desktop; on mobile it now retries until the scroll-lock releases.

  ## Affected Files

  - `components/landing/landing-hash-scroll.tsx` — export `scrollToId`
  - `components/navigation/public-nav-links.tsx` — use `scrollToId` in `handleSectionClick`
  - `components/landing/landing-footer.tsx` — use `scrollToId` in `handleHashClick`



  Closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior for in-page links on the home page, making section jumps more consistent.
  * Fixed hash-link clicks so repeated clicks on the same section still scroll correctly.
  * Updated footer and navigation links to use the same scrolling behavior for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->