### PR TITLE
fix: gate catalog/profile loading behind auth check in useCreateDealInit

### DIFF
--- a/hooks/use-create-deal-init.ts
+++ b/hooks/use-create-deal-init.ts
@@ -13,7 +13,12 @@ export function useCreateDealInit() {
 
   useEffect(() => {
     const init = async () => {
-      const authResult = supabase.auth.getUser()
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) {
+        router.push('/auth/login')
+        return
+      }
+      setUserId(user.id)
       let products: SupplierProductRow[] = []
       try {
         const res = await fetch('/api/catalog')
@@ -49,12 +54,6 @@ export function useCreateDealInit() {
         })) as unknown as SupplierProductRow[]
       }
       setSupplierProducts(products)
-      const { data: { user } } = await authResult
-      if (!user) {
-        router.push('/auth/login')
-        return
-      }
-      setUserId(user.id)
     }
     init()
   }, [router, supabase])


### PR DESCRIPTION
## Summary
`supabase.auth.getUser()` was fired without `await`, allowing unauthenticated users to trigger catalog and profile fetches before being redirected. Moved auth check to the top of `init()` with an early return.

## Changes
- `hooks/use-create-deal-init.ts`: await auth first, redirect if no user, then fetch data.

## Testing
- `grep -n "authResult"` returns empty.
- `tsc --noEmit` no new errors.

## Notes
No changes to the authenticated flow.

Closes #95 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the sign-in check during deal setup without changing the user experience.
  * Users who are not signed in are still sent to the login page, and signed-in users continue into the flow normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->