### PR TITLE
fix: rollback deal and milestones on escrow deployment failure

### DIFF
--- a/hooks/use-create-deal-submit.ts
+++ b/hooks/use-create-deal-submit.ts
@@ -138,6 +138,7 @@ export function useCreateDealSubmit() {
   ): Promise<{ ok: true } | { ok: false; error: string }> => {
     setIsSubmitting(true)
     setError(null)
+    let insertedDealId: string | undefined
 
     try {
       if (!params.userId) return { ok: false, error: 'User not authenticated' }
@@ -194,6 +195,7 @@ export function useCreateDealSubmit() {
         .single()
 
       if (dealError) throw dealError
+      insertedDealId = deal.id
 
       const milestones = params.milestones.map((m) => {
         const pct = Number(m.percentage)
@@ -241,6 +243,9 @@ export function useCreateDealSubmit() {
       const message = err instanceof Error ? err.message : 'An unexpected error occurred'
       console.error('Error creating deal:', err)
       setError(message)
+      if (insertedDealId) {
+        await supabase.from('deals').delete().eq('id', insertedDealId)
+      }
       return { ok: false, error: message }
     } finally {
       setIsSubmitting(false)


### PR DESCRIPTION
## Summary
Deal and milestone rows were persisted before escrow deployment. On failure, they remained as orphaned records. Added a compensating delete in the catch block — FK cascade handles milestones automatically.

## Changes
- `hooks/use-create-deal-submit.ts`: track `insertedDealId`, delete on catch.

## Testing
- `tsc --noEmit` no new errors.

## Notes
Reorder wasn't viable — escrow needs `deal.id` as `engagementId`.

Closes #98 