### PR TITLE
fix: validate contractId and handle escrow update error in useCreateDealSubmit

### DIFF
--- a/hooks/use-create-deal-submit.ts
+++ b/hooks/use-create-deal-submit.ts
@@ -227,14 +227,20 @@ export function useCreateDealSubmit() {
         provider: params.provider,
       })
 
-      await supabase
+      if (!contractId) {
+        throw new Error('Escrow contract ID was not confirmed')
+      }
+
+      const { error: updateError } = await supabase
         .from('deals')
         .update({
           escrow_id: deal.id,
-          escrow_contract_address: contractId ?? null,
+          escrow_contract_address: contractId,
           escrow_status: 'initialized',
         })
         .eq('id', deal.id)
+
+      if (updateError) throw updateError
 
       return { ok: true }
     } catch (err) {


### PR DESCRIPTION
## Summary
`submit` returned `{ ok: true }` when `contractId` was undefined or the Supabase update failed silently. Both cases now throw and route through the catch block.

## Changes
- `hooks/use-create-deal-submit.ts`: assert `contractId`, capture `updateError`, remove `?? null`.

## Testing
- `tsc --noEmit` no new errors.

Closes #99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deal submission reliability by validating that an escrow contract ID is confirmed before saving.
  * Prevented incomplete deal records by avoiding fallback values when storing the escrow contract address.
  * Added error handling for the deal update step so failures are surfaced instead of silently continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->