### PR TITLE
Refactor: Extract business logic from deal-repayment-panel.tsx

### DIFF
--- a/components/deals/deal-repayment-panel.tsx
+++ b/components/deals/deal-repayment-panel.tsx
@@ -14,12 +14,11 @@ import { useI18n } from '@/lib/i18n/provider'
 import { useWallet } from '@/hooks/use-wallet'
 import { useRepaymentEscrow } from '@/hooks/use-repayment-escrow'
 import {
-  repaymentEscrowAmount,
-  repaymentBreakdown,
-  repaymentRemainingAmount,
-} from '@/lib/deals/fees'
-import { computeInvestorReturns } from '@/lib/deals/investor-metrics'
-import { MERCATO_PLATFORM_ADDRESS } from '@/lib/trustless/config'
+  computeRepaymentState,
+  canFund as canFundCheck,
+  canRelease as canReleaseCheck,
+  canAddMilestone as canAddMilestoneCheck,
+} from '@/lib/deals/repayment-eligibility'
 import { stellarExpertContractUrl } from '@/lib/stellar/explorer'
 import { Badge } from '@/components/ui/badge'
 
@@ -30,14 +29,6 @@ interface DealRepaymentPanelProps {
   fetchDeal: () => Promise<Deal | null>
   onDealUpdate: (deal: Deal) => void
 }
-
-const FUNDABLE_STATUSES = new Set([
-  'escrow_initialized',
-  'funding',
-  'ready_to_release',
-  'partially_released',
-  'funded',
-])
 
 export function DealRepaymentPanel({
   deal,
@@ -58,37 +49,35 @@ export function DealRepaymentPanel({
   const [fundAmount, setFundAmount] = useState('')
   const [addAmount, setAddAmount] = useState('')
 
-  const apr = deal.yieldAPR ?? 0
-  const { profit } = computeInvestorReturns(deal.priceUSDC, apr, deal.term)
-  const breakdown = repaymentBreakdown(deal.priceUSDC, profit)
-  const escrowAmount =
-    deal.repaymentTotalAmount && deal.repaymentTotalAmount > 0
-      ? deal.repaymentTotalAmount
-      : repaymentEscrowAmount(deal.priceUSDC, profit)
-  const status = deal.repaymentStatus ?? 'none'
-  const milestones = deal.repaymentMilestones ?? []
-  const openMilestones = milestones.filter((m) => !m.released)
-  const openAmount = openMilestones.reduce((sum, m) => sum + m.amount, 0)
-  const scheduledAmounts = milestones.map((m) => m.amount)
-  const remainingToSchedule = repaymentRemainingAmount(escrowAmount, scheduledAmounts)
-  const currentMilestone = openMilestones[0]
-  const defaultFundAmount =
-    openAmount > 0 ? openAmount : remainingToSchedule > 0 ? remainingToSchedule : escrowAmount
+  const {
+    status,
+    milestones,
+    openMilestones,
+    currentMilestone,
+    escrowAmount,
+    openAmount,
+    remainingToSchedule,
+    defaultFundAmount,
+    breakdown,
+  } = computeRepaymentState(deal)
 
   if (deal.status === 'awaiting_funding') return null
 
-  const canFund = isPyme && Boolean(deal.escrowAddress) && FUNDABLE_STATUSES.has(status)
-  const canRelease =
-    (isAdmin || walletInfo?.address === MERCATO_PLATFORM_ADDRESS) &&
-    Boolean(deal.escrowAddress) &&
-    Boolean(currentMilestone) &&
-    (status === 'ready_to_release' || status === 'funded')
-  const canAddMilestone =
-    (isAdmin || walletInfo?.address === MERCATO_PLATFORM_ADDRESS) &&
-    Boolean(deal.escrowAddress) &&
-    remainingToSchedule > 0 &&
-    status !== 'none' &&
-    status !== 'order_confirmed'
+  const canFund = canFundCheck(isPyme, deal.escrowAddress, status)
+  const canRelease = canReleaseCheck(
+    isAdmin,
+    walletInfo?.address,
+    deal.escrowAddress,
+    currentMilestone,
+    status
+  )
+  const canAddMilestone = canAddMilestoneCheck(
+    isAdmin,
+    walletInfo?.address,
+    deal.escrowAddress,
+    remainingToSchedule,
+    status
+  )
 
   const refresh = async () => {
     const updated = await fetchDeal()

--- a/lib/deals/repayment-eligibility.ts
+++ b/lib/deals/repayment-eligibility.ts
@@ -1,0 +1,98 @@
+import type { Deal, RepaymentStatus, RepaymentMilestoneCache } from '@/lib/types'
+import { computeInvestorReturns } from '@/lib/deals/investor-metrics'
+import {
+  repaymentEscrowAmount,
+  repaymentBreakdown,
+  repaymentRemainingAmount,
+} from '@/lib/deals/fees'
+import { MERCATO_PLATFORM_ADDRESS } from '@/lib/trustless/config'
+
+export const FUNDABLE_STATUSES: ReadonlySet<RepaymentStatus> = new Set([
+  'escrow_initialized',
+  'funding',
+  'ready_to_release',
+  'partially_released',
+  'funded',
+])
+
+export interface RepaymentState {
+  status: RepaymentStatus
+  milestones: RepaymentMilestoneCache[]
+  openMilestones: RepaymentMilestoneCache[]
+  currentMilestone: RepaymentMilestoneCache | undefined
+  escrowAmount: number
+  openAmount: number
+  remainingToSchedule: number
+  defaultFundAmount: number
+  breakdown: ReturnType<typeof repaymentBreakdown>
+}
+
+export function computeRepaymentState(deal: Deal): RepaymentState {
+  const apr = deal.yieldAPR ?? 0
+  const { profit } = computeInvestorReturns(deal.priceUSDC, apr, deal.term)
+  const breakdown = repaymentBreakdown(deal.priceUSDC, profit)
+  const escrowAmount =
+    deal.repaymentTotalAmount && deal.repaymentTotalAmount > 0
+      ? deal.repaymentTotalAmount
+      : repaymentEscrowAmount(deal.priceUSDC, profit)
+  const status = deal.repaymentStatus ?? 'none'
+  const milestones = deal.repaymentMilestones ?? []
+  const openMilestones = milestones.filter((m) => !m.released)
+  const openAmount = openMilestones.reduce((sum, m) => sum + m.amount, 0)
+  const scheduledAmounts = milestones.map((m) => m.amount)
+  const remainingToSchedule = repaymentRemainingAmount(escrowAmount, scheduledAmounts)
+  const currentMilestone = openMilestones[0]
+  const defaultFundAmount =
+    openAmount > 0 ? openAmount : remainingToSchedule > 0 ? remainingToSchedule : escrowAmount
+
+  return {
+    status,
+    milestones,
+    openMilestones,
+    currentMilestone,
+    escrowAmount,
+    openAmount,
+    remainingToSchedule,
+    defaultFundAmount,
+    breakdown,
+  }
+}
+
+export function canFund(
+  isPyme: boolean,
+  escrowAddress: string | undefined,
+  status: RepaymentStatus,
+): boolean {
+  return isPyme && Boolean(escrowAddress) && FUNDABLE_STATUSES.has(status)
+}
+
+export function canRelease(
+  isAdmin: boolean,
+  walletAddress: string | undefined,
+  escrowAddress: string | undefined,
+  currentMilestone: RepaymentMilestoneCache | undefined,
+  status: RepaymentStatus,
+): boolean {
+  return (
+    (isAdmin || walletAddress === MERCATO_PLATFORM_ADDRESS) &&
+    Boolean(escrowAddress) &&
+    Boolean(currentMilestone) &&
+    (status === 'ready_to_release' || status === 'funded')
+  )
+}
+
+export function canAddMilestone(
+  isAdmin: boolean,
+  walletAddress: string | undefined,
+  escrowAddress: string | undefined,
+  remainingToSchedule: number,
+  status: RepaymentStatus,
+): boolean {
+  return (
+    (isAdmin || walletAddress === MERCATO_PLATFORM_ADDRESS) &&
+    Boolean(escrowAddress) &&
+    remainingToSchedule > 0 &&
+    status !== 'none' &&
+    status !== 'order_confirmed'
+  )
+}


### PR DESCRIPTION
Closes #120

Here's what we did:

- Created lib/deals/repayment-eligibility.ts which has:
  - FUNDABLE_STATUSES constant
  - computeRepaymentState function that calculates all the necessary state for the repayment panel
  - canFund , canRelease , and canAddMilestone pure functions for eligibility checks!
- Updated components/deals/deal-repayment-panel.tsx to import and use the new functions!
- Did NOT touch hooks/use-repayment-escrow.ts at all!
- No type errors!
- The panel's behavior should be exactly the same!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repayment panel state and action availability for more consistent funding, release, and milestone scheduling controls.
  * Standardized repayment totals, fees, escrow amounts, and milestone calculations across the interface.
  * Ensured repayment actions are enabled only when the deal meets the required status and eligibility conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->