### PR TITLE
refactor: split step components out of supplier-product-form.tsx (#116)

### DIFF
--- a/components/supplier-profile/product-form-steps/product-basics-step.tsx
+++ b/components/supplier-profile/product-form-steps/product-basics-step.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { getLocalizedCategoryLabel, PRODUCT_CATEGORIES } from '@/lib/categories'
+import type { ProductFormState } from '@/lib/supplier-profile/types'
+import { useI18n } from '@/lib/i18n/provider'
+
+const UNIT_VALUES = ['unit', 'kg', 'lb', 'box', 'case', 'pallet', 'liter', 'm'] as const
+
+export function ProductBasicsStep({
+  formProduct,
+  onChange,
+}: {
+  formProduct: ProductFormState
+  onChange: (patch: Partial<ProductFormState>) => void
+}) {
+  const { t, messages } = useI18n()
+
+  const unitLabel = (unit: string) => {
+    const key = `supplierProfile.unit.${unit}`
+    const label = t(key)
+    return label === key ? unit : label
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium">{t('supplierProfile.wizardStepBasicsTitle')}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {t('supplierProfile.wizardStepBasicsHint')}
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="form-name">{t('supplierProfile.formProductName')}</Label>
+          <Input
+            id="form-name"
+            value={formProduct.name}
+            onChange={(e) => onChange({ name: e.target.value })}
+            placeholder={t('supplierProfile.formProductNamePh')}
+            autoComplete="off"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="form-category">{t('supplierProfile.formCategory')}</Label>
+          <Select
+            value={formProduct.category || undefined}
+            onValueChange={(v) => onChange({ category: v })}
+          >
+            <SelectTrigger id="form-category">
+              <SelectValue placeholder={t('supplierProfile.formSelectCategory')} />
+            </SelectTrigger>
+            <SelectContent>
+              {PRODUCT_CATEGORIES.map((c) => (
+                <SelectItem key={c.value} value={c.value}>
+                  {getLocalizedCategoryLabel(c.value, messages)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="form-sku">{t('supplierProfile.formSku')}</Label>
+          <Input
+            id="form-sku"
+            value={formProduct.sku}
+            onChange={(e) => onChange({ sku: e.target.value })}
+            placeholder={t('supplierProfile.formSkuPh')}
+            autoComplete="off"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="form-unit">{t('supplierProfile.formUnit')}</Label>
+          <Select value={formProduct.unit} onValueChange={(v) => onChange({ unit: v })}>
+            <SelectTrigger id="form-unit">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {UNIT_VALUES.map((u) => (
+                <SelectItem key={u} value={u}>
+                  {unitLabel(u)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="form-desc">{t('supplierProfile.formDescription')}</Label>
+        <Textarea
+          id="form-desc"
+          value={formProduct.description}
+          onChange={(e) => onChange({ description: e.target.value })}
+          placeholder={t('supplierProfile.formDescriptionPh')}
+          rows={3}
+          className="resize-none"
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/supplier-profile/product-form-steps/product-form-step-progress.tsx
+++ b/components/supplier-profile/product-form-steps/product-form-step-progress.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { Progress } from '@/components/ui/progress'
+import { useI18n } from '@/lib/i18n/provider'
+import { TOTAL_STEPS, type ProductFormStep } from './types'
+
+export function ProductFormStepProgress({ currentStep }: { currentStep: ProductFormStep }) {
+  const { t } = useI18n()
+  const progress = (currentStep / TOTAL_STEPS) * 100
+
+  return (
+    <div className="mb-5">
+      <div className="mb-2 flex items-center justify-between text-sm">
+        <span className="font-medium">
+          {t('supplierProfile.wizardStepProgress', {
+            current: currentStep,
+            total: TOTAL_STEPS,
+          })}
+        </span>
+        <span className="text-muted-foreground">
+          {t('supplierProfile.wizardProgressComplete', {
+            percent: Math.round(progress),
+          })}
+        </span>
+      </div>
+      <Progress value={progress} className="h-2" />
+    </div>
+  )
+}

--- a/components/supplier-profile/product-form-steps/product-media-step.tsx
+++ b/components/supplier-profile/product-form-steps/product-media-step.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useRef, useState } from 'react'
+import { Upload } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import type { ProductFormState } from '@/lib/supplier-profile/types'
+import { useI18n } from '@/lib/i18n/provider'
+
+export function ProductMediaStep({
+  formProduct,
+  onChange,
+}: {
+  formProduct: ProductFormState
+  onChange: (patch: Partial<ProductFormState>) => void
+}) {
+  const { t } = useI18n()
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleFile = (file: File) => {
+    const validTypes = ['image/jpeg', 'image/png', 'image/webp']
+    if (!validTypes.includes(file.type)) {
+      toast.error(t('supplierProfile.toastImageTypeError'))
+      return
+    }
+
+    const maxSize = 5 * 1024 * 1024
+    if (file.size > maxSize) {
+      toast.error(t('supplierProfile.toastImageSizeError'))
+      return
+    }
+
+    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
+      URL.revokeObjectURL(formProduct.imagePreview)
+    }
+
+    const previewUrl = URL.createObjectURL(file)
+    onChange({ imageFile: file, imagePreview: previewUrl })
+  }
+
+  const handleRemoveImage = () => {
+    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
+      URL.revokeObjectURL(formProduct.imagePreview)
+    }
+    onChange({ imageFile: null, imagePreview: null })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium">{t('supplierProfile.wizardStepMediaTitle')}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {t('supplierProfile.wizardStepMediaHint')}
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label>{t('supplierProfile.formProductImage')}</Label>
+        {formProduct.imagePreview ? (
+          <div className="flex items-center gap-4 rounded-xl border border-border/70 bg-muted/20 p-4">
+            <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg border border-border/60 bg-muted/40">
+              <img
+                src={formProduct.imagePreview}
+                alt=""
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <div className="min-w-0 flex-1 space-y-1">
+              <p className="truncate text-sm font-medium text-foreground">
+                {formProduct.imageFile
+                  ? formProduct.imageFile.name
+                  : t('supplierProfile.formProductImage')}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {formProduct.imageFile
+                  ? `${(formProduct.imageFile.size / (1024 * 1024)).toFixed(2)} MB`
+                  : ''}
+              </p>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                className="mt-1 h-8 rounded-full text-xs"
+                onClick={handleRemoveImage}
+              >
+                {t('supplierProfile.formProductImageRemove')}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div
+            onDragOver={(e) => {
+              e.preventDefault()
+              setIsDragging(true)
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault()
+              setIsDragging(false)
+              const file = e.dataTransfer.files?.[0]
+              if (file) handleFile(file)
+            }}
+            onClick={() => fileInputRef.current?.click()}
+            className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-6 transition-all ${
+              isDragging
+                ? 'border-primary bg-primary/5'
+                : 'border-muted-foreground/20 bg-muted/5 hover:border-primary/50 hover:bg-muted/10'
+            }`}
+          >
+            <input
+              type="file"
+              ref={fileInputRef}
+              accept="image/png, image/jpeg, image/webp"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0]
+                if (file) handleFile(file)
+              }}
+            />
+            <Upload className="mb-2 h-8 w-8 text-muted-foreground" aria-hidden />
+            <p className="hidden text-center text-sm font-medium text-foreground sm:block">
+              {t('supplierProfile.formProductImageSelect')}
+            </p>
+            <p className="text-center text-sm font-medium text-foreground sm:hidden">
+              {t('supplierProfile.formProductImageSelectMobile')}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('supplierProfile.formProductImageHint')}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/supplier-profile/product-form-steps/product-pricing-step.tsx
+++ b/components/supplier-profile/product-form-steps/product-pricing-step.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import type { ProductFormState } from '@/lib/supplier-profile/types'
+import { useI18n } from '@/lib/i18n/provider'
+
+export function ProductPricingStep({
+  formProduct,
+  onChange,
+}: {
+  formProduct: ProductFormState
+  onChange: (patch: Partial<ProductFormState>) => void
+}) {
+  const { t } = useI18n()
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm font-medium">{t('supplierProfile.wizardStepPricingTitle')}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {t('supplierProfile.wizardStepPricingHint')}
+        </p>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="form-price">{t('supplierProfile.formPriceLabel')}</Label>
+        <Input
+          id="form-price"
+          type="number"
+          inputMode="decimal"
+          min="0"
+          step="0.01"
+          value={formProduct.price_per_unit}
+          onChange={(e) => onChange({ price_per_unit: e.target.value })}
+          placeholder={t('supplierProfile.formPricePh')}
+        />
+      </div>
+      <div className="space-y-4 rounded-xl border border-border/60 bg-muted/15 p-4">
+        <div>
+          <p className="text-sm font-medium">{t('supplierProfile.formInventorySection')}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t('supplierProfile.formInventoryHint')}
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="form-stock">{t('supplierProfile.formStockOnHand')}</Label>
+            <Input
+              id="form-stock"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              step="1"
+              value={formProduct.stock_quantity}
+              onChange={(e) => onChange({ stock_quantity: e.target.value })}
+              placeholder="0"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="form-reorder">{t('supplierProfile.formReorderPoint')}</Label>
+            <Input
+              id="form-reorder"
+              type="number"
+              inputMode="numeric"
+              min="0"
+              step="1"
+              value={formProduct.reorder_point}
+              onChange={(e) => onChange({ reorder_point: e.target.value })}
+              placeholder="0"
+            />
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label htmlFor="form-min-order">{t('supplierProfile.formMinOrder')}</Label>
+          <Input
+            id="form-min-order"
+            type="number"
+            inputMode="decimal"
+            min="0"
+            step="1"
+            value={formProduct.minimum_order}
+            onChange={(e) => onChange({ minimum_order: e.target.value })}
+            placeholder={t('supplierProfile.formMinOrderPh')}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="form-delivery">{t('supplierProfile.formDelivery')}</Label>
+          <Input
+            id="form-delivery"
+            value={formProduct.delivery_time}
+            onChange={(e) => onChange({ delivery_time: e.target.value })}
+            placeholder={t('supplierProfile.formDeliveryPh')}
+            autoComplete="off"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/supplier-profile/product-form-steps/types.ts
+++ b/components/supplier-profile/product-form-steps/types.ts
@@ -1,0 +1,3 @@
+export const TOTAL_STEPS = 3
+
+export type ProductFormStep = 1 | 2 | 3

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -4,13 +4,13 @@ import { useEffect, useRef, useState } from 'react'
 import { ArrowRight, Loader2, Upload } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import type { ProductFormState } from '@/lib/supplier-profile/types'
 import { useI18n } from '@/lib/i18n/provider'
 import { TOTAL_STEPS, type ProductFormStep } from './product-form-steps/types'
 import { ProductFormStepProgress } from './product-form-steps/product-form-step-progress'
 import { ProductBasicsStep } from './product-form-steps/product-basics-step'
+import { ProductPricingStep } from './product-form-steps/product-pricing-step'
 
 type SupplierProductFormProps = {
   formProduct: ProductFormState
@@ -22,101 +22,6 @@ type SupplierProductFormProps = {
   submittingLabel: string
   /** Bump when the dialog opens so the wizard restarts at step 1. */
   resetKey: string | number | boolean
-}
-
-function ProductPricingStep({
-  formProduct,
-  onChange,
-}: {
-  formProduct: ProductFormState
-  onChange: (patch: Partial<ProductFormState>) => void
-}) {
-  const { t } = useI18n()
-
-  return (
-    <div className="space-y-4">
-      <div>
-        <p className="text-sm font-medium">{t('supplierProfile.wizardStepPricingTitle')}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {t('supplierProfile.wizardStepPricingHint')}
-        </p>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="form-price">{t('supplierProfile.formPriceLabel')}</Label>
-        <Input
-          id="form-price"
-          type="number"
-          inputMode="decimal"
-          min="0"
-          step="0.01"
-          value={formProduct.price_per_unit}
-          onChange={(e) => onChange({ price_per_unit: e.target.value })}
-          placeholder={t('supplierProfile.formPricePh')}
-        />
-      </div>
-      <div className="space-y-4 rounded-xl border border-border/60 bg-muted/15 p-4">
-        <div>
-          <p className="text-sm font-medium">{t('supplierProfile.formInventorySection')}</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {t('supplierProfile.formInventoryHint')}
-          </p>
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="form-stock">{t('supplierProfile.formStockOnHand')}</Label>
-            <Input
-              id="form-stock"
-              type="number"
-              inputMode="numeric"
-              min="0"
-              step="1"
-              value={formProduct.stock_quantity}
-              onChange={(e) => onChange({ stock_quantity: e.target.value })}
-              placeholder="0"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="form-reorder">{t('supplierProfile.formReorderPoint')}</Label>
-            <Input
-              id="form-reorder"
-              type="number"
-              inputMode="numeric"
-              min="0"
-              step="1"
-              value={formProduct.reorder_point}
-              onChange={(e) => onChange({ reorder_point: e.target.value })}
-              placeholder="0"
-            />
-          </div>
-        </div>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="form-min-order">{t('supplierProfile.formMinOrder')}</Label>
-          <Input
-            id="form-min-order"
-            type="number"
-            inputMode="decimal"
-            min="0"
-            step="1"
-            value={formProduct.minimum_order}
-            onChange={(e) => onChange({ minimum_order: e.target.value })}
-            placeholder={t('supplierProfile.formMinOrderPh')}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="form-delivery">{t('supplierProfile.formDelivery')}</Label>
-          <Input
-            id="form-delivery"
-            value={formProduct.delivery_time}
-            onChange={(e) => onChange({ delivery_time: e.target.value })}
-            placeholder={t('supplierProfile.formDeliveryPh')}
-            autoComplete="off"
-          />
-        </div>
-      </div>
-    </div>
-  )
 }
 
 function ProductMediaStep({

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Progress } from '@/components/ui/progress'
 import { Textarea } from '@/components/ui/textarea'
 import {
   Select,
@@ -19,6 +18,7 @@ import { getLocalizedCategoryLabel, PRODUCT_CATEGORIES } from '@/lib/categories'
 import type { ProductFormState } from '@/lib/supplier-profile/types'
 import { useI18n } from '@/lib/i18n/provider'
 import { TOTAL_STEPS, type ProductFormStep } from './product-form-steps/types'
+import { ProductFormStepProgress } from './product-form-steps/product-form-step-progress'
 
 const UNIT_VALUES = ['unit', 'kg', 'lb', 'box', 'case', 'pallet', 'liter', 'm'] as const
 
@@ -347,30 +347,6 @@ function ProductMediaStep({
           </div>
         )}
       </div>
-    </div>
-  )
-}
-
-function ProductFormStepProgress({ currentStep }: { currentStep: ProductFormStep }) {
-  const { t } = useI18n()
-  const progress = (currentStep / TOTAL_STEPS) * 100
-
-  return (
-    <div className="mb-5">
-      <div className="mb-2 flex items-center justify-between text-sm">
-        <span className="font-medium">
-          {t('supplierProfile.wizardStepProgress', {
-            current: currentStep,
-            total: TOTAL_STEPS,
-          })}
-        </span>
-        <span className="text-muted-foreground">
-          {t('supplierProfile.wizardProgressComplete', {
-            percent: Math.round(progress),
-          })}
-        </span>
-      </div>
-      <Progress value={progress} className="h-2" />
     </div>
   )
 }

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -18,11 +18,9 @@ import {
 import { getLocalizedCategoryLabel, PRODUCT_CATEGORIES } from '@/lib/categories'
 import type { ProductFormState } from '@/lib/supplier-profile/types'
 import { useI18n } from '@/lib/i18n/provider'
+import { TOTAL_STEPS, type ProductFormStep } from './product-form-steps/types'
 
 const UNIT_VALUES = ['unit', 'kg', 'lb', 'box', 'case', 'pallet', 'liter', 'm'] as const
-const TOTAL_STEPS = 3
-
-type ProductFormStep = 1 | 2 | 3
 
 type SupplierProductFormProps = {
   formProduct: ProductFormState

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -6,21 +6,11 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Textarea } from '@/components/ui/textarea'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { getLocalizedCategoryLabel, PRODUCT_CATEGORIES } from '@/lib/categories'
 import type { ProductFormState } from '@/lib/supplier-profile/types'
 import { useI18n } from '@/lib/i18n/provider'
 import { TOTAL_STEPS, type ProductFormStep } from './product-form-steps/types'
 import { ProductFormStepProgress } from './product-form-steps/product-form-step-progress'
-
-const UNIT_VALUES = ['unit', 'kg', 'lb', 'box', 'case', 'pallet', 'liter', 'm'] as const
+import { ProductBasicsStep } from './product-form-steps/product-basics-step'
 
 type SupplierProductFormProps = {
   formProduct: ProductFormState
@@ -32,101 +22,6 @@ type SupplierProductFormProps = {
   submittingLabel: string
   /** Bump when the dialog opens so the wizard restarts at step 1. */
   resetKey: string | number | boolean
-}
-
-function ProductBasicsStep({
-  formProduct,
-  onChange,
-}: {
-  formProduct: ProductFormState
-  onChange: (patch: Partial<ProductFormState>) => void
-}) {
-  const { t, messages } = useI18n()
-
-  const unitLabel = (unit: string) => {
-    const key = `supplierProfile.unit.${unit}`
-    const label = t(key)
-    return label === key ? unit : label
-  }
-
-  return (
-    <div className="space-y-4">
-      <div>
-        <p className="text-sm font-medium">{t('supplierProfile.wizardStepBasicsTitle')}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {t('supplierProfile.wizardStepBasicsHint')}
-        </p>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="form-name">{t('supplierProfile.formProductName')}</Label>
-          <Input
-            id="form-name"
-            value={formProduct.name}
-            onChange={(e) => onChange({ name: e.target.value })}
-            placeholder={t('supplierProfile.formProductNamePh')}
-            autoComplete="off"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="form-category">{t('supplierProfile.formCategory')}</Label>
-          <Select
-            value={formProduct.category || undefined}
-            onValueChange={(v) => onChange({ category: v })}
-          >
-            <SelectTrigger id="form-category">
-              <SelectValue placeholder={t('supplierProfile.formSelectCategory')} />
-            </SelectTrigger>
-            <SelectContent>
-              {PRODUCT_CATEGORIES.map((c) => (
-                <SelectItem key={c.value} value={c.value}>
-                  {getLocalizedCategoryLabel(c.value, messages)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label htmlFor="form-sku">{t('supplierProfile.formSku')}</Label>
-          <Input
-            id="form-sku"
-            value={formProduct.sku}
-            onChange={(e) => onChange({ sku: e.target.value })}
-            placeholder={t('supplierProfile.formSkuPh')}
-            autoComplete="off"
-          />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="form-unit">{t('supplierProfile.formUnit')}</Label>
-          <Select value={formProduct.unit} onValueChange={(v) => onChange({ unit: v })}>
-            <SelectTrigger id="form-unit">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {UNIT_VALUES.map((u) => (
-                <SelectItem key={u} value={u}>
-                  {unitLabel(u)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="form-desc">{t('supplierProfile.formDescription')}</Label>
-        <Textarea
-          id="form-desc"
-          value={formProduct.description}
-          onChange={(e) => onChange({ description: e.target.value })}
-          placeholder={t('supplierProfile.formDescriptionPh')}
-          rows={3}
-          className="resize-none"
-        />
-      </div>
-    </div>
-  )
 }
 
 function ProductPricingStep({

--- a/components/supplier-profile/supplier-product-form.tsx
+++ b/components/supplier-profile/supplier-product-form.tsx
@@ -1,16 +1,16 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { ArrowRight, Loader2, Upload } from 'lucide-react'
+import { ArrowRight, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Label } from '@/components/ui/label'
 import type { ProductFormState } from '@/lib/supplier-profile/types'
 import { useI18n } from '@/lib/i18n/provider'
 import { TOTAL_STEPS, type ProductFormStep } from './product-form-steps/types'
 import { ProductFormStepProgress } from './product-form-steps/product-form-step-progress'
 import { ProductBasicsStep } from './product-form-steps/product-basics-step'
 import { ProductPricingStep } from './product-form-steps/product-pricing-step'
+import { ProductMediaStep } from './product-form-steps/product-media-step'
 
 type SupplierProductFormProps = {
   formProduct: ProductFormState
@@ -22,133 +22,6 @@ type SupplierProductFormProps = {
   submittingLabel: string
   /** Bump when the dialog opens so the wizard restarts at step 1. */
   resetKey: string | number | boolean
-}
-
-function ProductMediaStep({
-  formProduct,
-  onChange,
-}: {
-  formProduct: ProductFormState
-  onChange: (patch: Partial<ProductFormState>) => void
-}) {
-  const { t } = useI18n()
-  const [isDragging, setIsDragging] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-
-  const handleFile = (file: File) => {
-    const validTypes = ['image/jpeg', 'image/png', 'image/webp']
-    if (!validTypes.includes(file.type)) {
-      toast.error(t('supplierProfile.toastImageTypeError'))
-      return
-    }
-
-    const maxSize = 5 * 1024 * 1024
-    if (file.size > maxSize) {
-      toast.error(t('supplierProfile.toastImageSizeError'))
-      return
-    }
-
-    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
-      URL.revokeObjectURL(formProduct.imagePreview)
-    }
-
-    const previewUrl = URL.createObjectURL(file)
-    onChange({ imageFile: file, imagePreview: previewUrl })
-  }
-
-  const handleRemoveImage = () => {
-    if (formProduct.imagePreview && formProduct.imagePreview.startsWith('blob:')) {
-      URL.revokeObjectURL(formProduct.imagePreview)
-    }
-    onChange({ imageFile: null, imagePreview: null })
-  }
-
-  return (
-    <div className="space-y-4">
-      <div>
-        <p className="text-sm font-medium">{t('supplierProfile.wizardStepMediaTitle')}</p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
-          {t('supplierProfile.wizardStepMediaHint')}
-        </p>
-      </div>
-      <div className="space-y-2">
-        <Label>{t('supplierProfile.formProductImage')}</Label>
-        {formProduct.imagePreview ? (
-          <div className="flex items-center gap-4 rounded-xl border border-border/70 bg-muted/20 p-4">
-            <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-lg border border-border/60 bg-muted/40">
-              <img
-                src={formProduct.imagePreview}
-                alt=""
-                className="h-full w-full object-cover"
-              />
-            </div>
-            <div className="min-w-0 flex-1 space-y-1">
-              <p className="truncate text-sm font-medium text-foreground">
-                {formProduct.imageFile
-                  ? formProduct.imageFile.name
-                  : t('supplierProfile.formProductImage')}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {formProduct.imageFile
-                  ? `${(formProduct.imageFile.size / (1024 * 1024)).toFixed(2)} MB`
-                  : ''}
-              </p>
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                className="mt-1 h-8 rounded-full text-xs"
-                onClick={handleRemoveImage}
-              >
-                {t('supplierProfile.formProductImageRemove')}
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <div
-            onDragOver={(e) => {
-              e.preventDefault()
-              setIsDragging(true)
-            }}
-            onDragLeave={() => setIsDragging(false)}
-            onDrop={(e) => {
-              e.preventDefault()
-              setIsDragging(false)
-              const file = e.dataTransfer.files?.[0]
-              if (file) handleFile(file)
-            }}
-            onClick={() => fileInputRef.current?.click()}
-            className={`flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-6 transition-all ${
-              isDragging
-                ? 'border-primary bg-primary/5'
-                : 'border-muted-foreground/20 bg-muted/5 hover:border-primary/50 hover:bg-muted/10'
-            }`}
-          >
-            <input
-              type="file"
-              ref={fileInputRef}
-              accept="image/png, image/jpeg, image/webp"
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0]
-                if (file) handleFile(file)
-              }}
-            />
-            <Upload className="mb-2 h-8 w-8 text-muted-foreground" aria-hidden />
-            <p className="hidden text-center text-sm font-medium text-foreground sm:block">
-              {t('supplierProfile.formProductImageSelect')}
-            </p>
-            <p className="text-center text-sm font-medium text-foreground sm:hidden">
-              {t('supplierProfile.formProductImageSelectMobile')}
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              {t('supplierProfile.formProductImageHint')}
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
-  )
 }
 
 export function SupplierProductForm({


### PR DESCRIPTION
## Summary

Splits the 3 wizard steps and the progress bar out of `components/supplier-profile/supplier-product-form.tsx` into a new `components/supplier-profile/product-form-steps/` directory. The original file becomes a thin orchestrator that composes the extracted steps. Pure structural refactor — no behavior change.

### Changes
- New `product-form-steps/product-basics-step.tsx`, `product-pricing-step.tsx`, `product-media-step.tsx`, `product-form-step-progress.tsx`.
- New `product-form-steps/types.ts` for the shared `ProductFormStep` type and `TOTAL_STEPS`.
- `supplier-product-form.tsx` now imports and composes the steps; the `SupplierProductFormProps` contract and 3-step wizard behavior are unchanged.
- No changes to `lib/supplier-profile/types.ts` or upload/category logic.

### Verification
- Each extracted component body is byte-for-byte identical to the original inline definition (verbatim move).
- The orchestrator function body is unchanged — the diff only removes the inline components/constants and adds imports.
- Lint/type-check parity: the branch introduces zero new problems vs `develop` (132 pre-existing problems before and after).

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided three-step product creation form.
  * Added fields for product details, pricing, inventory, ordering, and delivery information.
  * Added image upload with drag-and-drop, file picker support, previews, and removal.
  * Added validation for supported image formats and file size.
  * Added localized step progress and form labels.

* **Refactor**
  * Improved product form organization without changing existing navigation and save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->