### PR TITLE
feat: add referral data model and schema (#109)

### DIFF
--- a/supabase/migrations/20260718000100_add_supplier_referrals.sql
+++ b/supabase/migrations/20260718000100_add_supplier_referrals.sql
@@ -1,0 +1,70 @@
+-- Add referral_code to supplier_companies and referred_by_supplier_id to profiles
+
+alter table public.supplier_companies
+  add column if not exists referral_code text;
+
+create or replace function public.generate_supplier_referral_code()
+returns text
+language plpgsql
+as $$
+declare
+  candidate text;
+  exists_already boolean;
+begin
+  loop
+    candidate := upper(substr(md5(gen_random_uuid()::text), 1, 8));
+    select exists(
+      select 1 from public.supplier_companies where referral_code = candidate
+    ) into exists_already;
+    exit when not exists_already;
+  end loop;
+  return candidate;
+end;
+$$;
+
+update public.supplier_companies
+set referral_code = public.generate_supplier_referral_code()
+where referral_code is null;
+
+alter table public.supplier_companies
+  alter column referral_code set not null;
+
+create unique index if not exists idx_supplier_companies_referral_code
+  on public.supplier_companies(referral_code);
+
+create or replace function public.set_supplier_referral_code()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.referral_code is null then
+    new.referral_code := public.generate_supplier_referral_code();
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists supplier_companies_set_referral_code on public.supplier_companies;
+create trigger supplier_companies_set_referral_code
+  before insert on public.supplier_companies
+  for each row
+  execute function public.set_supplier_referral_code();
+
+alter table public.profiles
+  add column if not exists referred_by_supplier_id uuid references public.supplier_companies(id);
+
+create or replace function public.lock_referred_by_supplier_id()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.referred_by_supplier_id := old.referred_by_supplier_id;
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_lock_referred_by on public.profiles;
+create trigger profiles_lock_referred_by
+  before update on public.profiles
+  for each row
+  execute function public.lock_referred_by_supplier_id();

--- a/supabase/migrations/20260718000200_update_handle_new_user_referral.sql
+++ b/supabase/migrations/20260718000200_update_handle_new_user_referral.sql
@@ -1,0 +1,39 @@
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  meta_type text := nullif(trim(coalesce(new.raw_user_meta_data->>'user_type', '')), '');
+  resolved_type text;
+  referred_by text := nullif(trim(coalesce(new.raw_user_meta_data->>'referred_by_supplier_id', '')), '');
+  resolved_referred_by uuid;
+begin
+  if meta_type in ('pyme', 'investor', 'supplier', 'admin') then
+    resolved_type := meta_type;
+  else
+    resolved_type := null;
+  end if;
+
+  begin
+    resolved_referred_by := referred_by::uuid;
+  exception when others then
+    resolved_referred_by := null;
+  end;
+
+  insert into public.profiles (id, email, user_type, company_name, contact_name, full_name, referred_by_supplier_id)
+  values (
+    new.id,
+    new.email,
+    resolved_type,
+    coalesce(new.raw_user_meta_data->>'company_name', null),
+    coalesce(new.raw_user_meta_data->>'contact_name', new.raw_user_meta_data->>'full_name', null),
+    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'contact_name', null),
+    resolved_referred_by
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260718000300_add_referral_notification_type.sql
+++ b/supabase/migrations/20260718000300_add_referral_notification_type.sql
@@ -1,0 +1,14 @@
+alter table public.notifications drop constraint if exists notifications_type_check;
+alter table public.notifications
+  add constraint notifications_type_check check (type in (
+    'deal_created',
+    'deal_funded',
+    'milestone_1_approved',
+    'milestone_2_approved',
+    'pyme_investor_deal_created',
+    'pyme_investor_deal_complete',
+    'repayment_escrow_needed',
+    'repayment_escrow_created',
+    'goods_shipped',
+    'referral_signup_completed'
+  ));


### PR DESCRIPTION
## Summary
Implements #109 — data model and schema for supplier→SME referrals.

## Changes
- New migration: unique `referral_code` on `supplier_companies` (auto-generated via 
  `BEFORE INSERT` trigger, backfilled for existing rows)
- New migration: nullable `referred_by_supplier_id` FK on `profiles`
- New migration: extends `handle_new_user()` to read `referred_by_supplier_id` from 
  signup metadata, same pattern as `full_name`/`company_name`
- New migration: adds `referral_signup_completed` to the notifications check constraint

## Note on RLS
`profiles_update_own` only restricts by row, not by column, so a `BEFORE UPDATE` trigger 
locks `referred_by_supplier_id` to its original value — it can only be set once, at signup.

## Testing
Applied against a personal Supabase project (no access to the shared instance as an 
external contributor). Verified with SQL that the FK exists, the notification type is 
included, and the lock trigger blocks reassignment on an existing row. `bun run build` 
passes clean.

## Notes
Found `20260528000100_add_product_images.sql` and `20260528000100_add_supplier_logo_url.sql` 
share a timestamp, which breaks a clean migration push — flagging in case it's worth fixing.

Closes #109