### PR TITLE
refactor: extract vault-math helpers and Row from mercato-vault-actions

### DIFF
--- a/__tests__/defindex/vault-math.test.ts
+++ b/__tests__/defindex/vault-math.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import { parsePositiveAmount, projectedEarnings } from '@/lib/defindex/vault-math'
+
+describe('parsePositiveAmount', () => {
+  test('parses a plain positive number', () => {
+    expect(parsePositiveAmount('10')).toBe(10)
+  })
+  test('accepts comma as decimal separator', () => {
+    expect(parsePositiveAmount('1,5')).toBe(1.5)
+  })
+  test('trims whitespace', () => {
+    expect(parsePositiveAmount('  20  ')).toBe(20)
+  })
+  test('rejects empty string', () => {
+    expect(parsePositiveAmount('')).toBeNull()
+  })
+  test('rejects zero', () => {
+    expect(parsePositiveAmount('0')).toBeNull()
+  })
+  test('rejects negative numbers', () => {
+    expect(parsePositiveAmount('-5')).toBeNull()
+  })
+  test('rejects non-numeric input', () => {
+    expect(parsePositiveAmount('abc')).toBeNull()
+  })
+  test('only replaces the first comma (documents current behavior)', () => {
+    expect(parsePositiveAmount('1,234,56')).toBeNull()
+  })
+})
+
+describe('projectedEarnings', () => {
+  test('computes yearly as simple interest on apy percentage', () => {
+    const { yearly } = projectedEarnings(1000, 5)
+    expect(yearly).toBe(50)
+  })
+  test('computes monthly as yearly / 12', () => {
+    const { monthly, yearly } = projectedEarnings(1000, 12)
+    expect(monthly).toBe(yearly / 12)
+  })
+  test('returns zero when apy is zero', () => {
+    expect(projectedEarnings(1000, 0)).toEqual({ monthly: 0, yearly: 0 })
+  })
+  test('returns zero when amount is zero', () => {
+    expect(projectedEarnings(0, 5)).toEqual({ monthly: 0, yearly: 0 })
+  })
+})

--- a/components/dashboard/mercato-vault-actions.tsx
+++ b/components/dashboard/mercato-vault-actions.tsx
@@ -8,13 +8,14 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { AlertCircle, Loader2 } from 'lucide-react'
-import { StellarMark, TokenAvatar } from '@/components/dashboard/vault-ui'
+import { Row, StellarMark, TokenAvatar } from '@/components/dashboard/vault-ui'
 import { formatDecimal, formatPercent } from '@/lib/format'
 import { getPrimarySupplyAsset } from '@/lib/defindex/vault-display'
 import {
   displayToRawTokenAmount,
   getPublicDefindexAssetDecimals,
 } from '@/lib/defindex/client-amounts'
+import { parsePositiveAmount, projectedEarnings } from '@/lib/defindex/vault-math'
 import { VaultAssetTrustlineCard } from '@/components/admin/vault-asset-trustline-card'
 import type { MercatoVaultMeta } from '@/hooks/useDefindex'
 import type { SendTransactionResponse } from '@defindex/sdk'
@@ -33,22 +34,6 @@ type Props = {
   onRefreshBalances?: () => Promise<unknown>
   initialTab?: 'deposit' | 'withdraw'
   variant?: 'panel' | 'card'
-}
-
-function parsePositiveAmount(raw: string): number | null {
-  const t = raw.trim().replace(',', '.')
-  if (!t) return null
-  const n = Number(t)
-  if (!Number.isFinite(n) || n <= 0) return null
-  return n
-}
-
-function projectedEarnings(amount: number, apy: number) {
-  const yearly = amount * (apy / 100)
-  return {
-    monthly: yearly / 12,
-    yearly,
-  }
 }
 
 export function MercatoVaultActions({
@@ -394,11 +379,4 @@ export function MercatoVaultActions({
   )
 }
 
-function Row({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-0.5">
-      <dt className="min-w-0 truncate text-muted-foreground">{label}</dt>
-      <dd className="shrink-0 text-right font-medium tabular-nums">{value}</dd>
-    </div>
-  )
-}
+

--- a/components/dashboard/vault-ui.tsx
+++ b/components/dashboard/vault-ui.tsx
@@ -114,3 +114,12 @@ export function StellarMark({ className }: { className?: string }) {
     </span>
   )
 }
+
+export function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-0.5">
+      <dt className="min-w-0 truncate text-muted-foreground">{label}</dt>
+      <dd className="shrink-0 text-right font-medium tabular-nums">{value}</dd>
+    </div>
+  )
+}

--- a/lib/defindex/vault-math.ts
+++ b/lib/defindex/vault-math.ts
@@ -1,0 +1,15 @@
+export function parsePositiveAmount(raw: string): number | null {
+  const t = raw.trim().replace(',', '.')
+  if (!t) return null
+  const n = Number(t)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+export function projectedEarnings(amount: number, apy: number) {
+  const yearly = amount * (apy / 100)
+  return {
+    monthly: yearly / 12,
+    yearly,
+  }
+}


### PR DESCRIPTION
## Summary
Extracts the pure helpers and `Row` component that were defined inline in
`mercato-vault-actions.tsx` (404 lines).

## Changes
- `parsePositiveAmount(raw)` and `projectedEarnings(amount, apy)` → `lib/defindex/vault-math.ts`
- `Row({ label, value })` → `components/dashboard/vault-ui.tsx`, alongside the other vault
  UI primitives (`TokenAvatar`, `StellarMark`)
- `MercatoVaultActions` behavior and props unchanged — only the import source changed

## Testing
Added `__tests__/defindex/vault-math.test.ts` with 12 unit tests covering both helpers,
including edge cases (empty string, zero, negative, non-numeric, comma-as-decimal, and the
current single-comma-replace behavior for malformed input like `"1,234,56"`). Full suite:
`bun test` → 47 pass, 0 fail. Lint clean on all four files (one pre-existing
`react-hooks/set-state-in-effect` warning, unrelated to this change).

## Notes
Confirmed the refactor is behavior-preserving both by diff (character-for-character match
against the original code) and by loading the live panel locally without runtime errors.
Closes #121