### PR TITLE
refactor: split up hooks/use-repayment-escrow.ts

### DIFF
--- a/__tests__/deals/repayment-escrow-helpers.test.ts
+++ b/__tests__/deals/repayment-escrow-helpers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  repaymentEngagementId,
+  roundUsdc,
+  isMilestoneReleased,
+  cacheMilestonesFromIndexer,
+  deriveRepaymentStatusFromMilestones,
+} from '@/lib/deals/repayment-escrow-helpers'
+
+describe('repayment escrow helpers', () => {
+  test('repaymentEngagementId suffixes the deal id', () => {
+    expect(repaymentEngagementId('deal-42')).toBe('deal-42:repayment')
+  })
+
+  test('roundUsdc rounds to 2 decimals', () => {
+    expect(roundUsdc(1.234)).toBe(1.23)
+    expect(roundUsdc(1.235)).toBe(1.24)
+    expect(roundUsdc(10)).toBe(10)
+  })
+
+  test('isMilestoneReleased reads flags and status', () => {
+    expect(isMilestoneReleased(undefined)).toBe(false)
+    expect(isMilestoneReleased({ flags: { released: true } } as never)).toBe(true)
+    expect(isMilestoneReleased({ status: 'RELEASED' } as never)).toBe(true)
+    expect(isMilestoneReleased({ status: 'completed' } as never)).toBe(true)
+    expect(isMilestoneReleased({ status: 'pending' } as never)).toBe(false)
+    expect(isMilestoneReleased({} as never)).toBe(false)
+  })
+
+  test('cacheMilestonesFromIndexer maps indexer milestones', () => {
+    expect(cacheMilestonesFromIndexer(null)).toEqual([])
+    expect(cacheMilestonesFromIndexer({ milestones: [] } as never)).toEqual([])
+    const cache = cacheMilestonesFromIndexer({
+      milestones: [
+        { description: 'M1', amount: 100, flags: { released: true } },
+        { amount: 50, status: 'pending' },
+      ],
+    } as never)
+    expect(cache).toEqual([
+      { index: 0, description: 'M1', amount: 100, released: true },
+      { index: 1, description: 'Milestone 2', amount: 50, released: false },
+    ])
+  })
+
+  test('deriveRepaymentStatusFromMilestones covers each state', () => {
+    expect(deriveRepaymentStatusFromMilestones([], 0)).toBe('escrow_initialized')
+
+    // all released, nothing remaining to schedule -> released
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [{ index: 0, description: 'M1', amount: 100, released: true }],
+        0,
+        100,
+      ),
+    ).toBe('released')
+
+    // all released but grossed total leaves a remainder -> partially_released
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [{ index: 0, description: 'M1', amount: 50, released: true }],
+        0,
+        100,
+      ),
+    ).toBe('partially_released')
+
+    // open milestone fully covered by balance -> ready_to_release
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [{ index: 0, description: 'M1', amount: 100, released: false }],
+        100,
+      ),
+    ).toBe('ready_to_release')
+
+    // partial balance, nothing releasable yet -> funding
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [{ index: 0, description: 'M1', amount: 100, released: false }],
+        40,
+      ),
+    ).toBe('funding')
+
+    // no balance, unreleased only -> escrow_initialized
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [{ index: 0, description: 'M1', amount: 100, released: false }],
+        0,
+      ),
+    ).toBe('escrow_initialized')
+
+    // one released, one open, no balance -> partially_released
+    expect(
+      deriveRepaymentStatusFromMilestones(
+        [
+          { index: 0, description: 'M1', amount: 100, released: true },
+          { index: 1, description: 'M2', amount: 100, released: false },
+        ],
+        0,
+      ),
+    ).toBe('partially_released')
+  })
+})

--- a/app/dashboard/admin/admin-resolve-dispute-dialog.tsx
+++ b/app/dashboard/admin/admin-resolve-dispute-dialog.tsx
@@ -18,6 +18,7 @@ import { useI18n } from '@/lib/i18n/provider'
 import { formatCurrency } from '@/lib/format'
 import { useWallet } from '@/hooks/use-wallet'
 import { useRepaymentEscrow } from '@/hooks/use-repayment-escrow'
+import { roundUsdc } from '@/lib/deals/repayment-escrow-helpers'
 import {
   MERCATO_DISPUTE_RESOLVER_ADDRESS,
 } from '@/lib/trustless/config'
@@ -39,10 +40,6 @@ interface AdminResolveDisputeDialogProps {
   target: ResolveDisputeTarget | null
   open: boolean
   onOpenChange: (open: boolean) => void
-}
-
-function roundUsdc(n: number): number {
-  return Math.round(n * 100) / 100
 }
 
 export function AdminResolveDisputeDialog({

--- a/hooks/use-repayment-escrow.ts
+++ b/hooks/use-repayment-escrow.ts
@@ -47,123 +47,20 @@ import {
 import { computeInvestorReturns } from '@/lib/deals/investor-metrics'
 import { createClient } from '@/lib/supabase/client'
 import type { RepaymentMilestoneCache, RepaymentStatus } from '@/lib/types'
-
-export function repaymentEngagementId(dealId: string): string {
-  return `${dealId}:repayment`
-}
-
-function roundUsdc(n: number): number {
-  return Math.round(n * 100) / 100
-}
-
-function isMilestoneReleased(m: MultiReleaseMilestone | undefined): boolean {
-  if (!m) return false
-  if (m.flags?.released === true) return true
-  const s = (m.status ?? '').toLowerCase()
-  return s === 'released' || s === 'completed'
-}
-
-export function cacheMilestonesFromIndexer(
-  escrow: GetEscrowsFromIndexerResponse | null | undefined,
-): RepaymentMilestoneCache[] {
-  if (!escrow?.milestones?.length) return []
-  return escrow.milestones.map((m, index) => {
-    const multi = m as MultiReleaseMilestone
-    return {
-      index,
-      description: multi.description ?? `Milestone ${index + 1}`,
-      amount: Number(multi.amount ?? 0),
-      released: isMilestoneReleased(multi),
-    }
-  })
-}
-
-export function deriveRepaymentStatusFromMilestones(
-  milestones: RepaymentMilestoneCache[],
-  balance: number,
-  totalGrossed = 0,
-): RepaymentStatus {
-  if (milestones.length === 0) return 'escrow_initialized'
-  const allReleased = milestones.every((m) => m.released)
-  const scheduled = milestones.reduce((sum, m) => sum + m.amount, 0)
-  const remaining =
-    totalGrossed > 0 ? repaymentRemainingAmount(totalGrossed, milestones.map((m) => m.amount)) : 0
-
-  if (allReleased) {
-    // More repayment still to schedule via updateEscrow
-    if (remaining > 0.01) return 'partially_released'
-    return 'released'
-  }
-
-  const anyReleased = milestones.some((m) => m.released)
-  const openAmount = milestones
-    .filter((m) => !m.released)
-    .reduce((sum, m) => sum + m.amount, 0)
-  if (openAmount > 0 && balance + 1e-9 >= openAmount) {
-    return 'ready_to_release'
-  }
-  if (balance > 0) return 'funding'
-  return anyReleased || scheduled > 0 ? (anyReleased ? 'partially_released' : 'escrow_initialized') : 'escrow_initialized'
-}
-
-interface DeployRepaymentParams {
-  dealId: string
-  /** Platform / admin wallet that signs deploy. */
-  adminAddress: string
-  investorAddress: string
-  principal: number
-  aprPercent: number
-  termDays: number
-  productName: string
-  /** Percent of total grossed for the first milestone (default 50). */
-  firstMilestonePercent?: number
-  provider: string | null
-}
-
-interface FundRepaymentParams {
-  dealId: string
-  contractId: string
-  pymeAddress: string
-  amount: number
-  provider: string | null
-}
-
-interface ReleaseMilestoneParams {
-  dealId: string
-  contractId: string
-  releaseSigner: string
-  milestoneIndex: number
-  provider: string | null
-}
-
-interface AddMilestoneParams {
-  dealId: string
-  contractId: string
-  adminAddress: string
-  investorAddress: string
-  /** Amount for the new milestone; defaults to remaining grossed total. */
-  amount?: number
-  description?: string
-  provider: string | null
-}
-
-interface DisputeMilestoneParams {
-  dealId: string
-  contractId: string
-  signer: string
-  milestoneIndex: number
-  provider: string | null
-}
-
-interface ResolveDisputeParams {
-  dealId: string
-  contractId: string
-  disputeResolver: string
-  milestoneIndex: number
-  /** Must sum to the milestone amount (post-fee rules enforced on-chain). */
-  distributions: Array<{ address: string; amount: number }>
-  provider: string | null
-}
+import {
+  repaymentEngagementId,
+  roundUsdc,
+  cacheMilestonesFromIndexer,
+  deriveRepaymentStatusFromMilestones,
+} from '@/lib/deals/repayment-escrow-helpers'
+import type {
+  DeployRepaymentParams,
+  FundRepaymentParams,
+  ReleaseMilestoneParams,
+  AddMilestoneParams,
+  DisputeMilestoneParams,
+  ResolveDisputeParams,
+} from '@/lib/deals/repayment-escrow-types'
 
 export function useRepaymentEscrow() {
   const supabase = useMemo(() => createClient(), [])

--- a/lib/deals/repayment-escrow-helpers.ts
+++ b/lib/deals/repayment-escrow-helpers.ts
@@ -1,0 +1,75 @@
+import type {
+  MultiReleaseMilestone,
+  GetEscrowsFromIndexerResponse,
+} from '@trustless-work/escrow'
+import { repaymentRemainingAmount } from '@/lib/deals/fees'
+import type { RepaymentMilestoneCache, RepaymentStatus } from '@/lib/types'
+
+export function repaymentEngagementId(dealId: string): string {
+  return `${dealId}:repayment`
+}
+
+export function roundUsdc(n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export function isMilestoneReleased(
+  m: MultiReleaseMilestone | undefined,
+): boolean {
+  if (!m) return false
+  if (m.flags?.released === true) return true
+  const s = (m.status ?? '').toLowerCase()
+  return s === 'released' || s === 'completed'
+}
+
+export function cacheMilestonesFromIndexer(
+  escrow: GetEscrowsFromIndexerResponse | null | undefined,
+): RepaymentMilestoneCache[] {
+  if (!escrow?.milestones?.length) return []
+  return escrow.milestones.map((m, index) => {
+    const multi = m as MultiReleaseMilestone
+    return {
+      index,
+      description: multi.description ?? `Milestone ${index + 1}`,
+      amount: Number(multi.amount ?? 0),
+      released: isMilestoneReleased(multi),
+    }
+  })
+}
+
+export function deriveRepaymentStatusFromMilestones(
+  milestones: RepaymentMilestoneCache[],
+  balance: number,
+  totalGrossed = 0,
+): RepaymentStatus {
+  if (milestones.length === 0) return 'escrow_initialized'
+  const allReleased = milestones.every((m) => m.released)
+  const scheduled = milestones.reduce((sum, m) => sum + m.amount, 0)
+  const remaining =
+    totalGrossed > 0
+      ? repaymentRemainingAmount(
+          totalGrossed,
+          milestones.map((m) => m.amount),
+        )
+      : 0
+
+  if (allReleased) {
+    // More repayment still to schedule via updateEscrow
+    if (remaining > 0.01) return 'partially_released'
+    return 'released'
+  }
+
+  const anyReleased = milestones.some((m) => m.released)
+  const openAmount = milestones
+    .filter((m) => !m.released)
+    .reduce((sum, m) => sum + m.amount, 0)
+  if (openAmount > 0 && balance + 1e-9 >= openAmount) {
+    return 'ready_to_release'
+  }
+  if (balance > 0) return 'funding'
+  return anyReleased || scheduled > 0
+    ? anyReleased
+      ? 'partially_released'
+      : 'escrow_initialized'
+    : 'escrow_initialized'
+}

--- a/lib/deals/repayment-escrow-types.ts
+++ b/lib/deals/repayment-escrow-types.ts
@@ -1,0 +1,58 @@
+export interface DeployRepaymentParams {
+  dealId: string
+  /** Platform / admin wallet that signs deploy. */
+  adminAddress: string
+  investorAddress: string
+  principal: number
+  aprPercent: number
+  termDays: number
+  productName: string
+  /** Percent of total grossed for the first milestone (default 50). */
+  firstMilestonePercent?: number
+  provider: string | null
+}
+
+export interface FundRepaymentParams {
+  dealId: string
+  contractId: string
+  pymeAddress: string
+  amount: number
+  provider: string | null
+}
+
+export interface ReleaseMilestoneParams {
+  dealId: string
+  contractId: string
+  releaseSigner: string
+  milestoneIndex: number
+  provider: string | null
+}
+
+export interface AddMilestoneParams {
+  dealId: string
+  contractId: string
+  adminAddress: string
+  investorAddress: string
+  /** Amount for the new milestone; defaults to remaining grossed total. */
+  amount?: number
+  description?: string
+  provider: string | null
+}
+
+export interface DisputeMilestoneParams {
+  dealId: string
+  contractId: string
+  signer: string
+  milestoneIndex: number
+  provider: string | null
+}
+
+export interface ResolveDisputeParams {
+  dealId: string
+  contractId: string
+  disputeResolver: string
+  milestoneIndex: number
+  /** Must sum to the milestone amount (post-fee rules enforced on-chain). */
+  distributions: Array<{ address: string; amount: number }>
+  provider: string | null
+}


### PR DESCRIPTION
Closes #115

Splits the 740-line `hooks/use-repayment-escrow.ts` into focused modules, leaving the hook as orchestration only.

## Changes
- **`lib/deals/repayment-escrow-helpers.ts`** (new) — pure, side-effect-free helpers moved out of the hook: `repaymentEngagementId`, `roundUsdc`, `isMilestoneReleased`, `cacheMilestonesFromIndexer`, `deriveRepaymentStatusFromMilestones`. Covered by `bun test`.
- **`lib/deals/repayment-escrow-types.ts`** (new) — the six action-parameter interfaces: `DeployRepaymentParams`, `FundRepaymentParams`, `ReleaseMilestoneParams`, `AddMilestoneParams`, `DisputeMilestoneParams`, `ResolveDisputeParams`.
- **`hooks/use-repayment-escrow.ts`** — shrinks from 740 to 637 lines; imports helpers/types from the new modules.
- **`__tests__/deals/repayment-escrow-helpers.test.ts`** (new) — `bun test` coverage for all five pure helpers.
- **`app/dashboard/admin/admin-resolve-dispute-dialog.tsx`** — drops its duplicated local `roundUsdc` and reuses the shared helper (DRY, enabled by the extraction).

## Public API unchanged
`useRepaymentEscrow`'s exported name and returned object shape are identical (`cacheMilestonesFromIndexer` is still re-exported in the returned object). Consumers — `app/dashboard/admin/pending-approvals.tsx`, `app/dashboard/admin/release-funds-fallback.tsx`, `components/deals/deal-repayment-panel.tsx` — require no changes.

## Verification
- `bun test` — 128 pass (5 new).
- `bunx tsc --noEmit` — no new errors introduced.
- Existing consumers compile without modification.
