### PR TITLE
feat: make admin vault-monitor polling visibility-aware and non-overl…

### DIFF
--- a/hooks/use-admin-vault-monitor.ts
+++ b/hooks/use-admin-vault-monitor.ts
@@ -20,11 +20,26 @@ export function useAdminVaultMonitor(options: UseAdminVaultMonitorOptions = {}) 
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const mountedRef = useRef(true)
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const isFetchingRef = useRef(false)
 
   const fetchMonitor = useCallback(
     async (opts?: { silent?: boolean }) => {
       if (!enabled) return
       const silent = opts?.silent ?? false
+
+      // A silent (background poll) tick that lands while a previous request
+      // is still in flight is dropped rather than queued, so slow responses
+      // can't overlap and race each other into state.
+      if (silent && isFetchingRef.current) return
+
+      // A manual refresh always takes priority: cancel any stale in-flight
+      // request so it can't clobber the fresh one's result when it lands.
+      abortControllerRef.current?.abort()
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+      isFetchingRef.current = true
+
       if (!silent) setIsRefreshing(true)
 
       try {
@@ -35,6 +50,7 @@ export function useAdminVaultMonitor(options: UseAdminVaultMonitorOptions = {}) 
 
         const response = await fetch(`/api/defindex/admin/monitor${qs}`, {
           credentials: 'include',
+          signal: controller.signal,
         })
 
         if (!response.ok) {
@@ -52,38 +68,81 @@ export function useAdminVaultMonitor(options: UseAdminVaultMonitorOptions = {}) 
           setError(null)
         }
       } catch (e) {
+        if (controller.signal.aborted) return
         if (mountedRef.current) {
           setError(e instanceof Error ? e.message : 'Failed to load vault monitor')
           setData(null)
         }
       } finally {
-        if (mountedRef.current) {
-          setIsLoading(false)
-          setIsRefreshing(false)
+        // Only the still-current request is allowed to clear the in-flight
+        // markers/loading state — a stale, aborted request's `finally` must
+        // not stomp on whatever request superseded it.
+        const isCurrent = abortControllerRef.current === controller
+        if (isCurrent) {
+          abortControllerRef.current = null
+          isFetchingRef.current = false
+          if (mountedRef.current) {
+            setIsLoading(false)
+            setIsRefreshing(false)
+          }
         }
       }
     },
     [enabled, vaultOverride],
   )
 
+  // Initial fetch whenever the request identity (vault/enabled) changes.
   useEffect(() => {
     mountedRef.current = true
     setIsLoading(true)
     void fetchMonitor()
 
-    if (!enabled || pollMs <= 0) {
-      return () => {
-        mountedRef.current = false
+    return () => {
+      mountedRef.current = false
+      abortControllerRef.current?.abort()
+    }
+  }, [fetchMonitor])
+
+  // Background polling, paused while the tab is hidden and refreshed on
+  // return to visibility instead of firing while nobody can see it.
+  useEffect(() => {
+    if (!enabled || pollMs <= 0) return
+
+    let intervalId: number | null = null
+
+    const stopInterval = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId)
+        intervalId = null
       }
     }
 
-    const interval = window.setInterval(() => {
+    const startInterval = () => {
+      if (intervalId !== null) return
+      intervalId = window.setInterval(() => {
+        void fetchMonitor({ silent: true })
+      }, pollMs)
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        stopInterval()
+        return
+      }
       void fetchMonitor({ silent: true })
-    }, pollMs)
+      stopInterval()
+      startInterval()
+    }
+
+    if (document.visibilityState === 'visible') {
+      startInterval()
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return () => {
-      mountedRef.current = false
-      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      stopInterval()
     }
   }, [enabled, fetchMonitor, pollMs])
 


### PR DESCRIPTION
## Summary

Reduced unnecessary admin-monitor traffic by pausing background polling while the browser tab is hidden and preventing concurrent/overlapping monitor requests in **hooks/use-admin-vault-monitor.ts**.
 closes #137 
## Changes

- **hooks/use-admin-vault-monitor.ts**
  - Added a `visibilitychange` listener that stops the polling interval when `document.visibilityState` is `'hidden'`, and on return to visibility fires an immediate silent refresh and restarts the interval.
  - Added an `isFetchingRef` guard so a background poll tick that arrives while a previous request is still in flight is dropped instead of overlapping.
  - Wired up `AbortController` per request: a manual `refresh()` call aborts any stale in-flight request before starting a new one; unmount and dependency changes (`enabled`, `vaultOverride`) also abort the current request via cleanup.
  - Added a `finally`-block guard (`abortControllerRef.current === controller`) so a stale, aborted request cannot clobber the loading/error state set by the request that superseded it.
  - Split the original single effect into two: one for the initial fetch (keyed on request identity), one for interval/visibility management (keyed on `enabled`, `pollMs`, `fetchMonitor`).
  - Preserved existing `isLoading` / `isRefreshing` / `error` semantics and the manual `refresh()` API surface.
- **app/api/defindex/admin/monitor/route.ts**
  - No changes made. The route is stateless per-request; the SDK calls it uses (`healthCheck`, `getVaultInfo`, `getVaultAPY`) don't expose an abort-signal hook, so cancellation is handled entirely on the client side.

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Pause or substantially back off polling while tab is hidden, resume on visibility | ✅ Done |
| Prevent a new poll while a previous monitor request is in flight | ✅ Done |
| Cancel obsolete fetches on cleanup/option changes via `AbortController` | ✅ Done |
| Manual refresh stays responsive (takes priority over stale in-flight poll) | ✅ Done |
| Preserve existing error/loading semantics | ✅ Done |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated monitoring results from overwriting newer data.
  * Improved handling of overlapping requests, cancellations, loading states, and errors.
  * Stopped active monitoring requests when leaving the page.

* **Performance**
  * Background monitoring now pauses when the page is hidden and resumes when it becomes visible, reducing unnecessary network activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->