### PR TITLE
perf: paginate investor portfolio history and aggregate open-escrow c…

### DIFF
--- a/__tests__/investments/portfolio-metrics.test.ts
+++ b/__tests__/investments/portfolio-metrics.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import { buildInvestorPortfolio } from '@/lib/investments/portfolio-metrics'
+import type { InvestorDeal } from '@/lib/investments/types'
+
+function makeDeal(overrides: Partial<InvestorDeal> = {}): InvestorDeal {
+  return {
+    id: overrides.id ?? 'deal-1',
+    title: 'Test Deal',
+    product_name: 'Widgets',
+    status: 'funded',
+    amount: 10_000,
+    interest_rate: 5,
+    term_days: 30,
+    created_at: '2026-01-01T00:00:00Z',
+    funded_at: '2026-01-01T00:00:00Z',
+    pyme_id: 'pyme-1',
+    escrow_contract_address: null,
+    pyme: { company_name: 'Test PyME' },
+    ...overrides,
+  }
+}
+
+function baseSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    total_deployed: 500_000,
+    active_capital: 100_000,
+    completed_principal: 400_000,
+    pending_yield_at_maturity: 5_000,
+    accrued_yield: 2_000,
+    realized_yield: 20_000,
+    weighted_apr: 5,
+    deal_count: 250,
+    active_count: 3,
+    completed_count: 247,
+    open_escrows_by_smb: { 'pyme-1': 4 },
+    ...overrides,
+  }
+}
+
+describe('buildInvestorPortfolio', () => {
+  test('KPI totals reflect the DB summary, independent of the fetched history page', () => {
+    const portfolio = buildInvestorPortfolio({
+      activeDeals: [makeDeal({ status: 'funded', pyme_id: 'pyme-1' })],
+      historyDeals: [makeDeal({ id: 'deal-2', status: 'completed' })], // only 1 of 247 fetched
+      historyTotal: 247,
+      page: 1,
+      pageSize: 10,
+      summary: baseSummary(),
+      displayName: 'Test',
+      smbFallback: 'SMB',
+      dealFallbackTitle: 'Deal',
+    })
+
+    expect(portfolio.metrics.dealCount).toBe(250) // full-history count, not page size
+    expect(portfolio.metrics.completedPrincipal).toBe(400_000)
+    expect(portfolio.active[0].openEscrowsWithSmb).toBe(4) // grouped count, not fetched rows
+    expect(portfolio.metrics.netReturnPercent).toBeCloseTo((20_000 / 400_000) * 100)
+  })
+
+  test('hasMore is true when more history pages remain', () => {
+    const portfolio = buildInvestorPortfolio({
+      activeDeals: [],
+      historyDeals: [makeDeal({ status: 'completed' })],
+      historyTotal: 35,
+      page: 1,
+      pageSize: 10,
+      summary: baseSummary({ deal_count: 35, active_count: 0, completed_count: 35 }),
+      displayName: null,
+      smbFallback: 'SMB',
+      dealFallbackTitle: 'Deal',
+    })
+
+    expect(portfolio.history.hasMore).toBe(true)
+  })
+
+  test('hasMore is false on the last page', () => {
+    const portfolio = buildInvestorPortfolio({
+      activeDeals: [],
+      historyDeals: [makeDeal({ status: 'completed' })],
+      historyTotal: 35,
+      page: 4,
+      pageSize: 10,
+      summary: baseSummary({ deal_count: 35, active_count: 0, completed_count: 35 }),
+      displayName: null,
+      smbFallback: 'SMB',
+      dealFallbackTitle: 'Deal',
+    })
+
+    expect(portfolio.history.hasMore).toBe(false)
+  })
+
+  test('open escrow counts come entirely from the grouped summary, not fetched deal rows', () => {
+    const portfolio = buildInvestorPortfolio({
+      activeDeals: [
+        makeDeal({ id: 'a1', pyme_id: 'pyme-1' }),
+        makeDeal({ id: 'a2', pyme_id: 'pyme-2' }),
+      ],
+      historyDeals: [],
+      historyTotal: 0,
+      page: 1,
+      pageSize: 10,
+      summary: baseSummary({ open_escrows_by_smb: { 'pyme-1': 4, 'pyme-2': 1 } }),
+      displayName: null,
+      smbFallback: 'SMB',
+      dealFallbackTitle: 'Deal',
+    })
+
+    expect(portfolio.active.find((d) => d.pyme_id === 'pyme-1')?.openEscrowsWithSmb).toBe(4)
+    expect(portfolio.active.find((d) => d.pyme_id === 'pyme-2')?.openEscrowsWithSmb).toBe(1)
+  })
+})

--- a/app/dashboard/investments/page.tsx
+++ b/app/dashboard/investments/page.tsx
@@ -7,7 +7,7 @@ import {
 import { getInvestorPortfolio } from '@/lib/investments/get-investor-portfolio'
 import { getServerDictionary } from '@/lib/i18n/server'
 
-type SearchParams = Promise<{ tab?: string }> | { tab?: string }
+type SearchParams = Promise<{ tab?: string; page?: string }> | { tab?: string; page?: string }
 
 export default async function DashboardInvestmentsPage({
   searchParams,
@@ -28,18 +28,26 @@ export default async function DashboardInvestmentsPage({
     .eq('id', user.id)
     .single()
 
-  const portfolio = await getInvestorPortfolio(supabase, user.id, profile, {
-    smbFallback: t.investments.smbFallbackName,
-    dealFallbackTitle: t.investments.dealFallbackTitle,
-  })
+  const params = searchParams
+    ? typeof (searchParams as Promise<{ tab?: string; page?: string }>).then === 'function'
+      ? await (searchParams as Promise<{ tab?: string; page?: string }>)
+      : (searchParams as { tab?: string; page?: string })
+    : {}
+
+  const page = Number(params.page) > 0 ? Number(params.page) : 1
+
+  const portfolio = await getInvestorPortfolio(
+    supabase,
+    user.id,
+    profile,
+    {
+      smbFallback: t.investments.smbFallbackName,
+      dealFallbackTitle: t.investments.dealFallbackTitle,
+    },
+    { page },
+  )
 
   if (!portfolio) redirect('/dashboard')
-
-  const params = searchParams
-    ? typeof (searchParams as Promise<{ tab?: string }>).then === 'function'
-      ? await (searchParams as Promise<{ tab?: string }>)
-      : (searchParams as { tab?: string })
-    : {}
 
   const tab = parseInvestmentsTab(params.tab)
 

--- a/components/investments/investments-dashboard.tsx
+++ b/components/investments/investments-dashboard.tsx
@@ -89,7 +89,7 @@ export function InvestmentsDashboard({ portfolio, tab, t }: InvestmentsDashboard
           }}
         />
 
-        {portfolio.deals.length === 0 ? (
+        {portfolio.metrics.dealCount === 0 ? (
           <InvestmentsEmpty
             labels={{
               emptyTitle: m.emptyTitle,

--- a/components/investments/investments-positions.tsx
+++ b/components/investments/investments-positions.tsx
@@ -50,11 +50,13 @@ export function InvestmentsPositions({
     other: labels.tabOther,
   }
 
+  const otherCount = portfolio.metrics.dealCount - portfolio.metrics.activeCount - portfolio.metrics.completedCount
+
   const counts: Record<PositionsTab, number> = {
-    all: portfolio.deals.length,
-    active: portfolio.active.length,
-    completed: portfolio.completed.length,
-    other: portfolio.other.length,
+    all: portfolio.metrics.dealCount,
+    active: portfolio.metrics.activeCount,
+    completed: portfolio.metrics.completedCount,
+    other: otherCount,
   }
 
   const showActive = tab === 'all' || tab === 'active'
@@ -65,6 +67,9 @@ export function InvestmentsPositions({
     (tab === 'active' && portfolio.active.length === 0) ||
     (tab === 'completed' && portfolio.completed.length === 0) ||
     (tab === 'other' && portfolio.other.length === 0)
+
+  const totalPages = Math.max(1, Math.ceil(portfolio.history.total / portfolio.history.pageSize))
+  const showHistoryPagination = tab !== 'active' && portfolio.history.total > portfolio.history.pageSize
 
   return (
     <section className="space-y-6">
@@ -119,15 +124,43 @@ export function InvestmentsPositions({
 
       {showCompleted && portfolio.completed.length > 0 && (
         <div>
-          <SectionHeading title={labels.completedHeading} count={portfolio.completed.length} />
+          <SectionHeading title={labels.completedHeading} count={portfolio.metrics.completedCount} />
           <CompletedList deals={portfolio.completed} labels={labels} />
         </div>
       )}
 
       {showOther && portfolio.other.length > 0 && (
         <div>
-          <SectionHeading title={labels.otherHeading} count={portfolio.other.length} />
+          <SectionHeading title={labels.otherHeading} count={otherCount} />
           <OtherList deals={portfolio.other} statusLabel={statusLabel} />
+        </div>
+      )}
+
+      {showHistoryPagination && (
+        <div className="flex items-center justify-between gap-4 pt-2">
+          <Link
+            href={`/dashboard/investments?tab=${tab}&page=${portfolio.history.page - 1}`}
+            aria-disabled={portfolio.history.page <= 1}
+            className={cn(
+              'text-sm font-medium text-muted-foreground hover:text-foreground',
+              portfolio.history.page <= 1 && 'pointer-events-none opacity-40',
+            )}
+          >
+            ← Previous
+          </Link>
+          <span className="text-xs text-muted-foreground">
+            Page {portfolio.history.page} of {totalPages}
+          </span>
+          <Link
+            href={`/dashboard/investments?tab=${tab}&page=${portfolio.history.page + 1}`}
+            aria-disabled={!portfolio.history.hasMore}
+            className={cn(
+              'text-sm font-medium text-muted-foreground hover:text-foreground',
+              !portfolio.history.hasMore && 'pointer-events-none opacity-40',
+            )}
+          >
+            Next →
+          </Link>
         </div>
       )}
     </section>

--- a/lib/investments/get-investor-portfolio.ts
+++ b/lib/investments/get-investor-portfolio.ts
@@ -2,6 +2,13 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { InvestorDeal } from './types'
 import { buildInvestorPortfolio } from './portfolio-metrics'
 
+const DEAL_COLUMNS = `id, title, product_name, status, amount, interest_rate, term_days,
+   created_at, funded_at, pyme_id, escrow_contract_address,
+   pyme:profiles!deals_pyme_id_fkey(company_name, full_name, contact_name)`
+
+const ACTIVE_STATUSES = ['funded', 'in_progress']
+const DEFAULT_PAGE_SIZE = 10
+
 export async function getInvestorPortfolio(
   supabase: SupabaseClient,
   userId: string,
@@ -12,45 +19,51 @@ export async function getInvestorPortfolio(
     contact_name?: string | null
   } | null,
   labels: { smbFallback: string; dealFallbackTitle: string },
+  pagination: { page?: number; pageSize?: number } = {},
 ) {
   if (profile?.user_type !== 'investor') {
     return null
   }
 
-  const { data: deals } = await supabase
-    .from('deals')
-    .select(
-      `id, title, product_name, status, amount, interest_rate, term_days,
-       created_at, funded_at, pyme_id, escrow_contract_address,
-       pyme:profiles!deals_pyme_id_fkey(company_name, full_name, contact_name)`,
-    )
-    .eq('investor_id', userId)
-    .order('funded_at', { ascending: false })
+  const page = Math.max(1, pagination.page ?? 1)
+  const pageSize = pagination.pageSize ?? DEFAULT_PAGE_SIZE
+  const from = (page - 1) * pageSize
+  const to = from + pageSize - 1
 
-  const list = (deals ?? []) as InvestorDeal[]
-  const pymeIds = [...new Set(list.map((d) => d.pyme_id).filter(Boolean))] as string[]
+  const [{ data: summaryRows }, { data: activeDeals }, { data: historyDeals, count: historyTotal }] =
+    await Promise.all([
+      supabase.rpc('get_investor_portfolio_summary', { p_investor_id: userId }),
+      supabase
+        .from('deals')
+        .select(DEAL_COLUMNS)
+        .eq('investor_id', userId)
+        .in('status', ACTIVE_STATUSES)
+        .order('funded_at', { ascending: false }),
+      supabase
+        .from('deals')
+        .select(DEAL_COLUMNS, { count: 'exact' })
+        .eq('investor_id', userId)
+        .not('status', 'in', `(${ACTIVE_STATUSES.join(',')})`)
+        .order('funded_at', { ascending: false })
+        .range(from, to),
+    ])
 
-  const { data: activeCounts } =
-    pymeIds.length > 0
-      ? await supabase
-          .from('deals')
-          .select('pyme_id')
-          .in('pyme_id', pymeIds)
-          .in('status', ['funded', 'in_progress'])
-      : { data: [] as { pyme_id: string }[] | null }
-
-  const openEscrowsBySmb: Record<string, number> = {}
-  for (const row of activeCounts ?? []) {
-    if (row.pyme_id) openEscrowsBySmb[row.pyme_id] = (openEscrowsBySmb[row.pyme_id] ?? 0) + 1
+  const summary = summaryRows?.[0]
+  if (!summary) {
+    return null
   }
 
   const displayName = profile?.company_name || profile?.full_name || profile?.contact_name || null
 
-  return buildInvestorPortfolio(
-    list,
-    openEscrowsBySmb,
+  return buildInvestorPortfolio({
+    activeDeals: (activeDeals ?? []) as InvestorDeal[],
+    historyDeals: (historyDeals ?? []) as InvestorDeal[],
+    historyTotal: historyTotal ?? 0,
+    page,
+    pageSize,
+    summary,
     displayName,
-    labels.smbFallback,
-    labels.dealFallbackTitle,
-  )
+    smbFallback: labels.smbFallback,
+    dealFallbackTitle: labels.dealFallbackTitle,
+  })
 }

--- a/lib/investments/portfolio-metrics.ts
+++ b/lib/investments/portfolio-metrics.ts
@@ -6,11 +6,11 @@ import type {
   InvestorPortfolio,
   MaturityEvent,
   PortfolioBucket,
+  PortfolioMetrics,
 } from './types'
 
 export function expectedYield(amount: number, rate: number, termDays: number): number {
   if (termDays <= 0 || rate <= 0) return 0
-  // Flat rate for the deal term (not annualized)
   return normalizeUSDC(amount * (rate / 100))
 }
 
@@ -19,7 +19,6 @@ export function accruedYield(amount: number, rate: number, fundedAt: string | nu
   const start = new Date(fundedAt).getTime()
   const elapsedMs = Math.max(0, Date.now() - start)
   const daysElapsed = Math.min(termDays, elapsedMs / 86_400_000)
-  // Accrue flat term yield proportionally over the deal term
   return normalizeUSDC(amount * (rate / 100) * (daysElapsed / termDays))
 }
 
@@ -51,91 +50,97 @@ function bucketForStatus(status: string): PortfolioBucket {
   return 'other'
 }
 
-export function buildInvestorPortfolio(
-  deals: InvestorDeal[],
-  openEscrowsBySmb: Record<string, number>,
-  displayName: string | null,
+type RawSummary = {
+  total_deployed: number
+  active_capital: number
+  completed_principal: number
+  pending_yield_at_maturity: number
+  accrued_yield: number
+  realized_yield: number
+  weighted_apr: number
+  deal_count: number
+  active_count: number
+  completed_count: number
+  open_escrows_by_smb: Record<string, number>
+}
+
+function enrichDeal(
+  d: InvestorDeal,
   smbFallback: string,
   dealFallbackTitle: string,
-): InvestorPortfolio {
-  const enriched: EnrichedInvestorDeal[] = deals.map((d) => {
-    const amountNum = Number(d.amount)
-    const apr = Number(d.interest_rate ?? 0)
-    const termDays = Number(d.term_days ?? 0)
-    const bucket = bucketForStatus(d.status)
-    const progress = termProgress(d.funded_at, d.term_days)
-    const yieldAtMaturity = expectedYield(amountNum, apr, termDays)
-    const accrued = bucket === 'active' ? accruedYield(amountNum, apr, d.funded_at, termDays) : 0
-
-    return {
-      ...d,
-      bucket,
-      displayTitle: d.product_name || d.title || dealFallbackTitle,
-      smbName: smbName(d.pyme, smbFallback),
-      amountNum,
-      apr,
-      termDays,
-      expectedYield: yieldAtMaturity,
-      accruedYield: accrued,
-      termProgress: progress,
-      openEscrowsWithSmb: d.pyme_id ? (openEscrowsBySmb[d.pyme_id] ?? 0) : 0,
-    }
-  })
-
-  const active = enriched.filter((d) => d.bucket === 'active')
-  const completed = enriched.filter((d) => d.bucket === 'completed')
-  const other = enriched.filter((d) => d.bucket === 'other')
-
-  let totalDeployed = 0
-  let activeCapital = 0
-  let completedPrincipal = 0
-  let pendingYieldAtMaturity = 0
-  let accruedYieldTotal = 0
-  let realizedYield = 0
-  let weightedAprNumerator = 0
-
-  for (const d of enriched) {
-    totalDeployed += d.amountNum
-    if (d.bucket === 'active') {
-      activeCapital += d.amountNum
-      pendingYieldAtMaturity += d.expectedYield
-      accruedYieldTotal += d.accruedYield
-      weightedAprNumerator += d.amountNum * d.apr
-    } else if (d.bucket === 'completed') {
-      completedPrincipal += d.amountNum
-      realizedYield += d.expectedYield
-    }
-  }
-
-  const weightedApr = activeCapital > 0 ? weightedAprNumerator / activeCapital : 0
-  const netReturnPercent =
-    completedPrincipal > 0 ? (realizedYield / completedPrincipal) * 100 : 0
-
-  const allocation = buildAllocation(active)
-  const maturities = buildMaturityEvents(active)
+  openEscrowsBySmb: Record<string, number>,
+): EnrichedInvestorDeal {
+  const amountNum = Number(d.amount)
+  const apr = Number(d.interest_rate ?? 0)
+  const termDays = Number(d.term_days ?? 0)
+  const bucket = bucketForStatus(d.status)
 
   return {
-    deals: enriched,
+    ...d,
+    bucket,
+    displayTitle: d.product_name || d.title || dealFallbackTitle,
+    smbName: smbName(d.pyme, smbFallback),
+    amountNum,
+    apr,
+    termDays,
+    expectedYield: expectedYield(amountNum, apr, termDays),
+    accruedYield: bucket === 'active' ? accruedYield(amountNum, apr, d.funded_at, termDays) : 0,
+    termProgress: termProgress(d.funded_at, d.term_days),
+    openEscrowsWithSmb: d.pyme_id ? (openEscrowsBySmb[d.pyme_id] ?? 0) : 0,
+  }
+}
+
+export function buildInvestorPortfolio(args: {
+  activeDeals: InvestorDeal[]
+  historyDeals: InvestorDeal[]
+  historyTotal: number
+  page: number
+  pageSize: number
+  summary: RawSummary
+  displayName: string | null
+  smbFallback: string
+  dealFallbackTitle: string
+}): InvestorPortfolio {
+  const openEscrowsBySmb = args.summary.open_escrows_by_smb ?? {}
+  const enrich = (d: InvestorDeal) => enrichDeal(d, args.smbFallback, args.dealFallbackTitle, openEscrowsBySmb)
+
+  const active = args.activeDeals.map(enrich)
+  const history = args.historyDeals.map(enrich)
+  const completed = history.filter((d) => d.bucket === 'completed')
+  const other = history.filter((d) => d.bucket === 'other')
+
+  const s = args.summary
+  const metrics: PortfolioMetrics = {
+    totalDeployed: Number(s.total_deployed),
+    activeCapital: Number(s.active_capital),
+    completedPrincipal: Number(s.completed_principal),
+    pendingYieldAtMaturity: Number(s.pending_yield_at_maturity),
+    accruedYield: Number(s.accrued_yield),
+    realizedYield: Number(s.realized_yield),
+    weightedApr: Number(s.weighted_apr),
+    netReturnPercent:
+      Number(s.completed_principal) > 0 ? (Number(s.realized_yield) / Number(s.completed_principal)) * 100 : 0,
+    dealCount: s.deal_count,
+    activeCount: s.active_count,
+    completedCount: s.completed_count,
+  }
+
+  return {
     active,
     completed,
     other,
-    metrics: {
-      totalDeployed,
-      activeCapital,
-      completedPrincipal,
-      pendingYieldAtMaturity,
-      accruedYield: accruedYieldTotal,
-      realizedYield,
-      weightedApr,
-      netReturnPercent,
-      dealCount: enriched.length,
-      activeCount: active.length,
-      completedCount: completed.length,
-    },
-    allocation,
-    maturities,
+    metrics,
+    allocation: buildAllocation(active),
+    maturities: buildMaturityEvents(active),
     openEscrowsBySmb,
-    displayName,
+    displayName: args.displayName,
+    history: {
+      deals: history,
+      page: args.page,
+      pageSize: args.pageSize,
+      total: args.historyTotal,
+      hasMore: args.page * args.pageSize < args.historyTotal,
+    },
   }
 }
 

--- a/lib/investments/types.ts
+++ b/lib/investments/types.ts
@@ -1,3 +1,26 @@
+export type PortfolioMetrics = {
+  totalDeployed: number
+  activeCapital: number
+  completedPrincipal: number
+  pendingYieldAtMaturity: number
+  accruedYield: number
+  realizedYield: number
+  weightedApr: number
+  netReturnPercent: number
+  dealCount: number
+  activeCount: number
+  completedCount: number
+}
+
+export type InvestorHistoryPage = {
+  deals: EnrichedInvestorDeal[]
+  page: number
+  pageSize: number
+  total: number
+  hasMore: boolean
+}
+
+
 export type InvestorDeal = {
   id: string
   title: string
@@ -52,25 +75,13 @@ export type MaturityEvent = {
 }
 
 export type InvestorPortfolio = {
-  deals: EnrichedInvestorDeal[]
   active: EnrichedInvestorDeal[]
   completed: EnrichedInvestorDeal[]
   other: EnrichedInvestorDeal[]
-  metrics: {
-    totalDeployed: number
-    activeCapital: number
-    completedPrincipal: number
-    pendingYieldAtMaturity: number
-    accruedYield: number
-    realizedYield: number
-    weightedApr: number
-    netReturnPercent: number
-    dealCount: number
-    activeCount: number
-    completedCount: number
-  }
+  metrics: PortfolioMetrics
   allocation: AllocationSlice[]
   maturities: MaturityEvent[]
   openEscrowsBySmb: Record<string, number>
   displayName: string | null
+  history: InvestorHistoryPage
 }

--- a/supabase/migrations/20260725094446_investor_portfolio_summary_rpc.sql
+++ b/supabase/migrations/20260725094446_investor_portfolio_summary_rpc.sql
@@ -1,0 +1,49 @@
+create or replace function public.get_investor_portfolio_summary(p_investor_id uuid)
+returns table (
+  total_deployed numeric,
+  active_capital numeric,
+  completed_principal numeric,
+  pending_yield_at_maturity numeric,
+  accrued_yield numeric,
+  realized_yield numeric,
+  weighted_apr numeric,
+  deal_count integer,
+  active_count integer,
+  completed_count integer,
+  open_escrows_by_smb jsonb
+)
+language sql
+stable
+as $$
+  with investor_deals as (
+    select * from public.deals where investor_id = p_investor_id
+  ),
+  escrow_counts as (
+    select d.pyme_id, count(*) as open_count
+    from public.deals d
+    where d.status in ('funded', 'in_progress')
+      and d.pyme_id in (select distinct pyme_id from investor_deals where pyme_id is not null)
+    group by d.pyme_id
+  )
+  select
+    coalesce(sum(id.amount), 0),
+    coalesce(sum(id.amount) filter (where id.status in ('funded','in_progress')), 0),
+    coalesce(sum(id.amount) filter (where id.status = 'completed'), 0),
+    coalesce(sum(id.amount * id.interest_rate / 100) filter (where id.status in ('funded','in_progress')), 0),
+    coalesce(sum(
+      id.amount * (id.interest_rate / 100)
+        * least(id.term_days, extract(epoch from (now() - id.funded_at)) / 86400) / id.term_days
+    ) filter (where id.status in ('funded','in_progress') and id.funded_at is not null and id.term_days > 0 and id.interest_rate > 0), 0),
+    coalesce(sum(id.amount * id.interest_rate / 100) filter (where id.status = 'completed'), 0),
+    case when coalesce(sum(id.amount) filter (where id.status in ('funded','in_progress')), 0) > 0
+      then sum(id.amount * id.interest_rate) filter (where id.status in ('funded','in_progress'))
+           / sum(id.amount) filter (where id.status in ('funded','in_progress'))
+      else 0 end,
+    count(*)::int,
+    count(*) filter (where id.status in ('funded','in_progress'))::int,
+    count(*) filter (where id.status = 'completed')::int,
+    coalesce((select jsonb_object_agg(pyme_id, open_count) from escrow_counts), '{}'::jsonb)
+  from investor_deals id;
+$$;
+
+grant execute on function public.get_investor_portfolio_summary(uuid) to authenticated;


### PR DESCRIPTION


## Problem
\`get-investor-portfolio.ts\` fetched every deal the investor ever funded, plus every active deal for every PyME they've dealt with just to count them client-side. \`portfolio-metrics.ts\` then looped the full set in memory to build KPIs, allocation, and maturities.

## Change
- New \`get_investor_portfolio_summary\` Postgres RPC computes KPI totals and open-escrow counts (grouped by PyME) over full investor history in the DB, so payload doesn't grow with history.
- Active deals are still fetched in full (this set is naturally bounded — it shrinks as deals complete).
- Completed/other deal history is now paginated via \`.range()\` instead of fetched in full.
- \`portfolio-metrics.ts\` only enriches the active deals + current history page, not the entire portfolio.
- Added tests verifying KPI totals reflect the DB summary independent of the fetched page, correct \`hasMore\` pagination behavior, and that escrow counts come from the grouped aggregate rather than fetched rows.

## Verification
- \`bun test\`: 136/136 passing
- \`bun run build\`: succeeds, \`/dashboard/investments\` builds as expected
- \`bun run lint\`: pre-existing repo-wide lint debt is unrelated to this PR (unchanged files); no new lint issues introduced

## Scope note
The history query currently mixes completed+other deals in one paginated fetch (split client-side by bucket, same as the original code did). Splitting each tab into its own independent pagination is a reasonable follow-up if reviewers want it, but out of scope here to keep the diff focused on the acceptance criteria."

Closes #141.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination for investment history with Previous and Next navigation.
  * Added portfolio summary metrics for totals, counts, yields, APR, and escrow activity.
  * Improved investment tabs to display accurate metric-based counts.
* **Bug Fixes**
  * Corrected empty-state detection for portfolios with paginated results.
  * Ensured portfolio metrics and escrow values remain accurate regardless of loaded history size.
* **Tests**
  * Added coverage for summary metrics, pagination boundaries, and escrow calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->