### PR TITLE
feat(pymes): add supplier referral trust badge

### DIFF
--- a/app/pymes/[id]/page.tsx
+++ b/app/pymes/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { Navigation } from '@/components/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Badge, badgeVariants } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Mail,
@@ -63,7 +63,7 @@ export default async function SmbDetailPage({
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('id, company_name, bio, full_name, contact_name, email, phone, address, user_type, country, sector, verified, stake_amount')
+    .select('id, company_name, bio, full_name, contact_name, email, phone, address, user_type, country, sector, verified, stake_amount, referred_by_supplier_id')
     .eq('id', id)
     .single()
 
@@ -77,11 +77,20 @@ export default async function SmbDetailPage({
     .eq('pyme_id', id)
     .order('created_at', { ascending: false })
   const reputationPromise = getReputation(supabase, id)
+  const referringSupplierPromise = profile.referred_by_supplier_id
+    ? supabase
+        .from('supplier_companies')
+        .select('id, company_name')
+        .eq('id', profile.referred_by_supplier_id)
+        .maybeSingle()
+    : null
 
-  const [{ data: allDeals }, reputation] = await Promise.all([
+  const [{ data: allDeals }, reputation, referringSupplierResult] = await Promise.all([
     dealsPromise,
     reputationPromise,
+    referringSupplierPromise,
   ])
+  const referringSupplier = referringSupplierResult?.data ?? null
 
   const dealsList = (allDeals ?? []).slice(0, 10) as DealRow[]
   const totalDeals = (allDeals ?? []).length
@@ -140,6 +149,16 @@ export default async function SmbDetailPage({
                     <CheckCircle2 className="h-3 w-3" />
                     {tr(m, 'smbDetail.verified')}
                   </Badge>
+                )}
+                {referringSupplier && (
+                  <Link
+                    href={`/suppliers/${referringSupplier.id}`}
+                    className={badgeVariants({ variant: 'outline', className: 'hover:bg-muted' })}
+                  >
+                    {tr(m, 'smbDetail.referredBySupplier', {
+                      company: referringSupplier.company_name,
+                    })}
+                  </Link>
                 )}
               </div>
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1243,6 +1243,7 @@
   "smbDetail": {
     "backToDirectory": "Back to SMBs",
     "verified": "Verified",
+    "referredBySupplier": "Referred by {company}",
     "reputationLabel": "Reputation",
     "statDealsMercato": "Deals on MERCATO",
     "statActiveDeals": "Active deals",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1243,6 +1243,7 @@
   "smbDetail": {
     "backToDirectory": "Volver a PyMEs",
     "verified": "Verificado",
+    "referredBySupplier": "Referido por {company}",
     "reputationLabel": "Reputación",
     "statDealsMercato": "Órdenes en MERCATO",
     "statActiveDeals": "Órdenes activas",


### PR DESCRIPTION
## Summary

Adds an investor-facing referral provenance signal to public PyME profiles.

PyMEs referred by an available supplier now display a localized **“Referred by {company}”** badge linking to that supplier’s public profile.

Closes #113

## Changes

- Include `referred_by_supplier_id` in the public PyME profile query.
- Conditionally retrieve only the referring supplier’s `id` and `company_name`.
- Run the supplier lookup alongside the existing deals and reputation requests.
- Render a compact linked badge beside the existing verified badge.
- Hide the badge when no referral exists or the supplier cannot be retrieved.
- Add matching English and Spanish translations.
- Keep the existing metrics, verified badge, page layout, and Contact & details card unchanged.
- Avoid the client referral API and additional referral helpers.

## Validation

- [x] Targeted ESLint passed.
- [x] English and Spanish translation keys match and include `{company}`.
- [x] Translation JSON parsing passed.
- [x] `git diff --check` passed.
- [x] 132 existing tests passed.
- [ ] One unrelated component test is blocked because `@happy-dom/global-registrator` is unavailable locally.
- [ ] Repository-wide TypeScript checking remains blocked by unrelated existing errors outside the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMB detail pages now display a linked “Referred by supplier” badge when applicable.
  * The badge shows the referring supplier’s company name and links to its profile.
  * Added English and Spanish translations for the new referral label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->