### PR TITLE
Fix/bound strategy allocation rendering

### DIFF
--- a/__tests__/defindex/vault-strategies.test.ts
+++ b/__tests__/defindex/vault-strategies.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from 'bun:test'
+import { flattenStrategyRows } from '@/lib/defindex/vault-strategies'
+import type { VaultMonitorAssetRow } from '@/lib/defindex/vault-monitor'
+
+function makeStrategy(overrides: Partial<VaultMonitorAssetRow['strategies'][0]> = {}) {
+  return {
+    address: overrides.address ?? 'CSTRAT' + Math.random().toString(36).slice(2, 10).toUpperCase(),
+    name: overrides.name ?? 'Strategy',
+    paused: overrides.paused ?? false,
+    allocatedDisplay: overrides.allocatedDisplay ?? 100,
+    allocatedRaw: overrides.allocatedRaw ?? '1000000000',
+  }
+}
+
+function makeAssetRow(
+  overrides: Partial<VaultMonitorAssetRow> & { strategies?: VaultMonitorAssetRow['strategies'] } = {},
+): VaultMonitorAssetRow {
+  return {
+    address: overrides.address ?? 'CASSET' + Math.random().toString(36).slice(2, 10).toUpperCase(),
+    name: overrides.name ?? 'USD Coin',
+    symbol: overrides.symbol ?? 'USDC',
+    idleDisplay: overrides.idleDisplay ?? 0,
+    investedDisplay: overrides.investedDisplay ?? 0,
+    totalDisplay: overrides.totalDisplay ?? 0,
+    idleRaw: overrides.idleRaw ?? '0',
+    investedRaw: overrides.investedRaw ?? '0',
+    totalRaw: overrides.totalRaw ?? '0',
+    idlePercent: overrides.idlePercent ?? 0,
+    strategies: overrides.strategies ?? [makeStrategy()],
+  }
+}
+
+describe('flattenStrategyRows', () => {
+  test('returns empty array for empty input', () => {
+    expect(flattenStrategyRows([])).toEqual([])
+  })
+
+  test('flattens single asset with single strategy', () => {
+    const strategy = makeStrategy({ name: 'Blend USDC', address: 'CBLEND001' })
+    const asset = makeAssetRow({ name: 'USD Coin', symbol: 'USDC', address: 'CUSDC001', strategies: [strategy] })
+    const result = flattenStrategyRows([asset])
+
+    expect(result).toHaveLength(1)
+    expect(result[0].asset).toEqual({ address: 'CUSDC001', name: 'USD Coin', symbol: 'USDC' })
+    expect(result[0].strategy).toBe(strategy)
+  })
+
+  test('flattens multiple assets with multiple strategies', () => {
+    const rows = [
+      makeAssetRow({ strategies: [makeStrategy(), makeStrategy(), makeStrategy()] }),
+      makeAssetRow({ strategies: [makeStrategy(), makeStrategy()] }),
+    ]
+    const result = flattenStrategyRows(rows)
+    expect(result).toHaveLength(5)
+  })
+
+  test('preserves asset context on each row', () => {
+    const rows = [
+      makeAssetRow({ name: 'USD Coin', symbol: 'USDC', address: 'CUSDC', strategies: [makeStrategy(), makeStrategy()] }),
+      makeAssetRow({ name: 'Euro Coin', symbol: 'EURC', address: 'CEURC', strategies: [makeStrategy()] }),
+    ]
+    const result = flattenStrategyRows(rows)
+
+    expect(result[0].asset.symbol).toBe('USDC')
+    expect(result[1].asset.symbol).toBe('USDC')
+    expect(result[2].asset.symbol).toBe('EURC')
+  })
+
+  test('preserves paused status', () => {
+    const paused = makeStrategy({ paused: true, name: 'Paused Strat' })
+    const active = makeStrategy({ paused: false, name: 'Active Strat' })
+    const result = flattenStrategyRows([makeAssetRow({ strategies: [paused, active] })])
+
+    expect(result[0].strategy.paused).toBe(true)
+    expect(result[1].strategy.paused).toBe(false)
+  })
+
+  test('handles asset with no strategies', () => {
+    const result = flattenStrategyRows([makeAssetRow({ strategies: [] })])
+    expect(result).toHaveLength(0)
+  })
+
+  test('handles large multi-asset strategy payloads', () => {
+    const assets = Array.from({ length: 20 }, (_, i) =>
+      makeAssetRow({
+        address: `CASSET${i}`,
+        name: `Asset ${i}`,
+        symbol: `A${i}`,
+        strategies: Array.from({ length: 10 }, (_, j) =>
+          makeStrategy({ address: `CSTRAT${i}_${j}`, name: `Strat ${i}-${j}` }),
+        ),
+      }),
+    )
+    const result = flattenStrategyRows(assets)
+
+    expect(result).toHaveLength(200)
+    // Spot-check: row 15 belongs to asset 1 (strategies 0-9 for asset 0, then 10-19 for asset 1)
+    expect(result[15].asset.address).toBe('CASSET1')
+    expect(result[15].strategy.address).toBe('CSTRAT1_5')
+  })
+})

--- a/components/dashboard/vault-detail-view.tsx
+++ b/components/dashboard/vault-detail-view.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useMemo, useState } from 'react'
 import Link from 'next/link'
 import { ArrowLeft, ExternalLink, Layers, Waves } from 'lucide-react'
 import { CopyableCodeLine } from '@/components/admin/copyable-code-line'
@@ -14,12 +15,15 @@ import {
   formatCompactCurrency,
   getPrimarySupplyAsset,
 } from '@/lib/defindex/vault-display'
+import { flattenStrategyRows, type FlatStrategyRow } from '@/lib/defindex/vault-strategies'
 import { formatCurrency, formatPercent } from '@/lib/format'
 import type { MercatoVaultMeta } from '@/hooks/useDefindex'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Activity, Landmark, TrendingUp, User } from 'lucide-react'
+
+const INITIAL_STRATEGY_LIMIT = 6
 
 type VaultDetailViewProps = {
   vaultMeta: MercatoVaultMeta | null
@@ -61,6 +65,14 @@ export function VaultDetailView({
   const apy = vaultMeta?.apy ?? 0
   const hasApy = Number.isFinite(apy) && apy > 0
   const assetCount = vaultMeta?.assetRows?.length ?? vaultMeta?.assets?.length ?? 0
+
+  const allStrategyRows = useMemo(
+    () => flattenStrategyRows(vaultMeta?.assetRows ?? []),
+    [vaultMeta?.assetRows],
+  )
+  const [showAll, setShowAll] = useState(false)
+  const hasMore = allStrategyRows.length > INITIAL_STRATEGY_LIMIT
+  const visibleRows = showAll ? allStrategyRows : allStrategyRows.slice(0, INITIAL_STRATEGY_LIMIT)
 
   return (
     <div className="space-y-8 animate-mercato-slide-up-fade">
@@ -190,41 +202,20 @@ export function VaultDetailView({
               </p>
             ) : (
               <div className="space-y-3">
-                {vaultMeta.assetRows.flatMap((asset) =>
-                  asset.strategies.map((strategy) => (
-                    <div
-                      key={strategy.address}
-                      className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-sm transition-shadow hover:shadow-md"
-                    >
-                      <div className="flex min-w-0 flex-col gap-3 border-b border-border/50 bg-muted/20 px-4 py-3 sm:flex-row sm:items-start sm:justify-between sm:px-5 sm:py-4">
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate font-medium">{strategy.name}</p>
-                          <p className="mt-0.5 text-xs text-muted-foreground">
-                            Asset · {asset.symbol}
-                          </p>
-                        </div>
-                        <div className="shrink-0 sm:text-right">
-                          <p className="font-display text-lg tabular-nums tracking-tight sm:text-xl">
-                            {formatCompactCurrency(strategy.allocatedDisplay)}
-                          </p>
-                          {strategy.paused && (
-                            <Badge
-                              variant="secondary"
-                              className="mt-1 bg-amber-500/15 text-amber-800 dark:text-amber-200"
-                            >
-                              Paused
-                            </Badge>
-                          )}
-                        </div>
-                      </div>
-                      <div className="min-w-0 px-4 py-3 sm:px-5">
-                        <CopyableCodeLine
-                          value={strategy.address}
-                          label="strategy contract"
-                        />
-                      </div>
-                    </div>
-                  )),
+                {visibleRows.map((row) => (
+                  <StrategyCard key={`${row.asset.address}-${row.strategy.address}`} row={row} />
+                ))}
+                {hasMore && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full rounded-xl"
+                    onClick={() => setShowAll((prev) => !prev)}
+                  >
+                    {showAll
+                      ? 'Show fewer'
+                      : `Show all ${allStrategyRows.length} strategies`}
+                  </Button>
                 )}
               </div>
             )}
@@ -248,6 +239,38 @@ export function VaultDetailView({
             variant="panel"
           />
         </div>
+      </div>
+    </div>
+  )
+}
+
+function StrategyCard({ row }: { row: FlatStrategyRow }) {
+  const { asset, strategy } = row
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border/70 bg-card shadow-sm transition-shadow hover:shadow-md">
+      <div className="flex min-w-0 flex-col gap-3 border-b border-border/50 bg-muted/20 px-4 py-3 sm:flex-row sm:items-start sm:justify-between sm:px-5 sm:py-4">
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium">{strategy.name}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Asset · {asset.symbol}
+          </p>
+        </div>
+        <div className="shrink-0 sm:text-right">
+          <p className="font-display text-lg tabular-nums tracking-tight sm:text-xl">
+            {formatCompactCurrency(strategy.allocatedDisplay)}
+          </p>
+          {strategy.paused && (
+            <Badge
+              variant="secondary"
+              className="mt-1 bg-amber-500/15 text-amber-800 dark:text-amber-200"
+            >
+              Paused
+            </Badge>
+          )}
+        </div>
+      </div>
+      <div className="min-w-0 px-4 py-3 sm:px-5">
+        <CopyableCodeLine value={strategy.address} label="strategy contract" />
       </div>
     </div>
   )

--- a/lib/defindex/vault-strategies.ts
+++ b/lib/defindex/vault-strategies.ts
@@ -1,0 +1,18 @@
+import type { VaultMonitorAssetRow, VaultMonitorStrategyRow } from './vault-monitor'
+
+export type FlatStrategyRow = {
+  asset: { address: string; name: string; symbol: string }
+  strategy: VaultMonitorStrategyRow
+}
+
+/** Flatten asset rows into a list of strategy entries with asset context attached. */
+export function flattenStrategyRows(assetRows: VaultMonitorAssetRow[]): FlatStrategyRow[] {
+  const rows: FlatStrategyRow[] = []
+  for (const asset of assetRows) {
+    const ctx = { address: asset.address, name: asset.name, symbol: asset.symbol }
+    for (const strategy of asset.strategies) {
+      rows.push({ asset: ctx, strategy })
+    }
+  }
+  return rows
+}


### PR DESCRIPTION
Closes #139

## Summary

Prevents the vault detail page from rendering an unbounded number of strategy
cards at once by introducing progressive disclosure with a configurable initial
limit.

## Root Cause

`vault-detail-view.tsx` used `assetRows.flatMap(…strategies.map(…))` to render
every strategy allocation card immediately. Each card includes formatting and
a copyable-contract UI. As the number of vault assets and strategies grows,
initial render, layout, and interaction costs scale linearly with no bound.

## Changes

- **New utility** `lib/defindex/vault-strategies.ts`: pure `flattenStrategyRows()`
  function that flattens `VaultMonitorAssetRow[]` into `{ asset, strategy }[]`
  tuples with asset context preserved.

- **Modified** `components/dashboard/vault-detail-view.tsx`:
  - Renders at most 6 strategy cards initially (`INITIAL_STRATEGY_LIMIT`).
  - Adds a "Show all N strategies" / "Show fewer" toggle when total exceeds the
    limit.
  - Extracted `StrategyCard` as a file-local component for readability.
  - Per-asset context, paused status, allocation amount, and contract-copy
    actions remain intact.

- **New tests** `__tests__/defindex/vault-strategies.test.ts`: 7 tests covering
  empty input, single/multi-asset flattening, asset context and paused status
  preservation, and a large payload (20 assets × 10 strategies = 200 rows).

## Tests

54 pass, 0 fail across all 5 test files (bun test v1.3.14).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added supplier referral codes and referral attribution for new profiles.
  - Added notifications for completed referral signups.
  - Improved vault strategy displays with asset details, paused status, and expandable strategy lists.
  - Added clearer KPI tiles and consistent dashboard information rows.

- **Improvements**
  - Vault deposit calculations now handle positive amounts, comma decimal separators, and projected monthly/yearly earnings more consistently.
  - Vault monitoring alerts now use consistent severity styling and icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->