### PR TITLE
Fix mobile layout for fiat conversion section on How it works page

### DIFF
--- a/app/how-it-works/how-it-works-view.tsx
+++ b/app/how-it-works/how-it-works-view.tsx
@@ -426,34 +426,36 @@ export function HowItWorksView() {
             hiwCardHover,
           )}
         >
-          <div className="flex flex-wrap items-start gap-5">
-            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
-              <RefreshCw
-                className="h-6 w-6 text-primary motion-safe:animate-spin motion-safe:[animation-duration:12s] motion-reduce:animate-none"
-                aria-hidden
-              />
-            </div>
-            <div className="flex-1 min-w-0">
-              <h3 className="mb-1 text-lg font-semibold">{hiw.fiatTitle}</h3>
-              <p className="mb-4 text-sm text-muted-foreground">{hiw.fiatDescription}</p>
-              <div className="flex flex-wrap gap-3">
-                {hiw.rampProviders.map((p, i) => (
-                  <div
-                    key={p.name}
-                    style={{ animationDelay: `${i * 60}ms` }}
-                    className={cn(
-                      'rounded-lg border border-border bg-background px-4 py-2',
-                      hiwEnter,
-                      'motion-safe:fill-mode-backwards',
-                    )}
-                  >
-                    <p className="text-sm font-semibold">{p.name}</p>
-                    <p className="text-xs text-muted-foreground">{p.region}</p>
-                  </div>
-                ))}
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+            <div className="flex min-w-0 flex-1 gap-4 sm:gap-5">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10">
+                <RefreshCw
+                  className="h-6 w-6 text-primary motion-safe:animate-spin motion-safe:[animation-duration:12s] motion-reduce:animate-none"
+                  aria-hidden
+                />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="mb-1 text-lg font-semibold leading-snug">{hiw.fiatTitle}</h3>
+                <p className="mb-4 text-sm leading-relaxed text-muted-foreground">{hiw.fiatDescription}</p>
+                <div className="flex flex-wrap gap-3">
+                  {hiw.rampProviders.map((p, i) => (
+                    <div
+                      key={p.name}
+                      style={{ animationDelay: `${i * 60}ms` }}
+                      className={cn(
+                        'rounded-lg border border-border bg-background px-4 py-2',
+                        hiwEnter,
+                        'motion-safe:fill-mode-backwards',
+                      )}
+                    >
+                      <p className="text-sm font-semibold">{p.name}</p>
+                      <p className="text-xs text-muted-foreground">{p.region}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
-            <Button asChild variant="outline" size="sm" className="shrink-0">
+            <Button asChild variant="outline" size="sm" className="w-full shrink-0 sm:w-auto">
               <Link href="/dashboard/ramp">
                 {hiw.addFunds}
                 <ArrowRight className="ml-2 h-3.5 w-3.5" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes the cramped text layout in the "How does Mercato manage local currency ↔ USDC conversion?" card on the How it works page when viewed on mobile.

## Problem
On narrow viewports, the icon, title/body text, and "Add funds" button were all in a single flex row. The button (`shrink-0`) stayed fixed width while the text column (`flex-1`) was squeezed into a very narrow column, causing aggressive word wrapping.

## Solution
- Stack the layout vertically on mobile (`flex-col`), keeping the icon beside the text content
- Move the "Add funds" CTA below the content on mobile (`w-full`), and keep it inline on `sm+` screens
- Add `leading-snug` / `leading-relaxed` for better readability on wrapped lines

## Test plan
- [ ] Open `/how-it-works` on a mobile viewport (~360px width)
- [ ] Confirm the fiat conversion card title and body use the full card width
- [ ] Confirm the "Add funds" button appears below the content on mobile
- [ ] Confirm desktop layout still looks correct at `sm` breakpoint and above
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd5aa-96f4-7def-8718-50f12f103858?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd5aa-96f4-7def-8718-50f12f103858&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the fiat on-ramp section layout for better responsiveness across screen sizes.
  * Updated heading and description typography.
  * Adjusted the action button to use a full-width layout on smaller screens and a more compact layout on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->