### PR TITLE
Fix on-chain order details layout on mobile

### DIFF
--- a/components/deals/deal-detail-tabs.tsx
+++ b/components/deals/deal-detail-tabs.tsx
@@ -31,7 +31,7 @@ export function DealDetailTabs({ deal, indexerEscrow }: DealDetailTabsProps) {
           <CardHeader className="pb-2">
             <CardTitle className="text-base">{t('dealDetail.blockchainInfo')}</CardTitle>
           </CardHeader>
-          <CardContent className="pt-0">
+          <CardContent className="min-w-0 pt-0">
             <DealOnChainPanel
               escrowAddress={deal.escrowAddress}
               fundingTxHash={deal.fundingTxHash}

--- a/components/deals/deal-on-chain-panel.tsx
+++ b/components/deals/deal-on-chain-panel.tsx
@@ -1,13 +1,16 @@
 'use client'
 
+import type { ReactNode } from 'react'
 import { AlertCircle, ExternalLink, ArrowRightLeft } from 'lucide-react'
 import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
+import { CopyableCodeLine } from '@/components/admin/copyable-code-line'
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/lib/i18n/provider'
 import {
   stellarExpertContractUrl,
   stellarExpertTxUrl,
 } from '@/lib/stellar/explorer'
+import { cn } from '@/lib/utils'
 
 type DealOnChainPanelProps = {
   escrowAddress?: string
@@ -21,6 +24,44 @@ type DealOnChainPanelProps = {
 function truncateId(id: string, head = 8, tail = 6) {
   if (id.length <= head + tail + 3) return id
   return `${id.slice(0, head)}…${id.slice(-tail)}`
+}
+
+function OnChainIdentifier({
+  value,
+  compact = false,
+  label,
+  actions,
+}: {
+  value: string
+  compact?: boolean
+  label?: string
+  actions?: ReactNode
+}) {
+  if (compact) {
+    return (
+      <div className="min-w-0 space-y-2">
+        <code className="block w-full min-w-0 break-all rounded-md bg-muted px-2 py-1.5 font-mono text-[11px] leading-relaxed sm:text-xs">
+          {truncateId(value)}
+        </code>
+        {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <CopyableCodeLine value={value} label={label} />
+      {actions ? <div className="flex flex-wrap items-center gap-2">{actions}</div> : null}
+    </div>
+  )
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+      {children}
+    </p>
+  )
 }
 
 export function DealOnChainPanel({
@@ -44,35 +85,37 @@ export function DealOnChainPanel({
   }
 
   return (
-    <div className={compact ? 'space-y-3' : 'space-y-4'}>
+    <div className={cn('min-w-0', compact ? 'space-y-3' : 'space-y-4')}>
       {fundingTxHash ? (
-        <div>
-          <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            {t('dealDetail.onChainActivityTitle')}
-          </p>
+        <div className="min-w-0">
+          <SectionLabel>{t('dealDetail.onChainActivityTitle')}</SectionLabel>
           <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2.5">
-            <div className="flex items-start gap-2">
+            <div className="flex min-w-0 items-start gap-2">
               <ArrowRightLeft className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
-              <div className="min-w-0 flex-1 space-y-1">
-                <p className="text-sm font-medium">{t('dealDetail.fundingPaymentTitle')}</p>
-                <p className="text-xs text-muted-foreground">
-                  {t('dealDetail.fundingPaymentDescription')}
-                </p>
-                <div className="flex flex-wrap items-center gap-2 pt-1">
-                  <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
-                    {compact ? truncateId(fundingTxHash) : fundingTxHash}
-                  </code>
-                  <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5" asChild>
-                    <a
-                      href={stellarExpertTxUrl(fundingTxHash)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Stellar Expert
-                      <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-                    </a>
-                  </Button>
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">{t('dealDetail.fundingPaymentTitle')}</p>
+                  <p className="break-words text-xs text-muted-foreground">
+                    {t('dealDetail.fundingPaymentDescription')}
+                  </p>
                 </div>
+                <OnChainIdentifier
+                  value={fundingTxHash}
+                  compact={compact}
+                  label={t('dealDetail.fundingPaymentTitle')}
+                  actions={
+                    <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5" asChild>
+                      <a
+                        href={stellarExpertTxUrl(fundingTxHash)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Stellar Expert
+                        <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                      </a>
+                    </Button>
+                  }
+                />
               </div>
             </div>
           </div>
@@ -80,35 +123,37 @@ export function DealOnChainPanel({
       ) : null}
 
       {escrowAddress ? (
-        <div>
-          <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            {t('dealDetail.escrowContract')}
-          </p>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            <code className="rounded-md bg-muted px-2 py-1 font-mono text-xs">
-              {compact ? truncateId(escrowAddress) : escrowAddress}
-            </code>
-            <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5" asChild>
-              <a
-                href={`https://viewer.trustlesswork.com/${escrowAddress}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                TrustlessWork
-                <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-              </a>
-            </Button>
-            <Button size="sm" variant="ghost" className="h-8 w-8 p-0" asChild>
-              <a
-                href={stellarExpertContractUrl(escrowAddress)}
-                target="_blank"
-                rel="noopener noreferrer"
-                title={t('dealDetail.titleStellarExpert')}
-              >
-                <ExternalLink className="h-4 w-4" aria-hidden />
-              </a>
-            </Button>
-          </div>
+        <div className="min-w-0">
+          <SectionLabel>{t('dealDetail.escrowContract')}</SectionLabel>
+          <OnChainIdentifier
+            value={escrowAddress}
+            compact={compact}
+            label={t('dealDetail.escrowContract')}
+            actions={
+              <>
+                <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5" asChild>
+                  <a
+                    href={`https://viewer.trustlesswork.com/${escrowAddress}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    TrustlessWork
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                  </a>
+                </Button>
+                <Button size="sm" variant="outline" className="h-8 gap-1.5 px-2.5" asChild>
+                  <a
+                    href={stellarExpertContractUrl(escrowAddress)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Stellar Expert
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                  </a>
+                </Button>
+              </>
+            }
+          />
         </div>
       ) : (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -117,31 +162,31 @@ export function DealOnChainPanel({
         </p>
       )}
 
-      {!compact && investorAddress && (
-        <div>
-          <p className="mb-1 text-sm font-medium">{t('dealDetail.investorAddress')}</p>
-          <code className="block break-all rounded bg-muted px-2 py-1 text-xs">{investorAddress}</code>
+      {!compact && investorAddress ? (
+        <div className="min-w-0">
+          <p className="mb-1.5 text-sm font-medium">{t('dealDetail.investorAddress')}</p>
+          <CopyableCodeLine value={investorAddress} label={t('dealDetail.investorAddress')} />
         </div>
-      )}
+      ) : null}
 
-      {!compact && supplierAddress && (
-        <div>
-          <p className="mb-1 text-sm font-medium">{t('dealDetail.supplierWalletAddress')}</p>
-          <code className="block break-all rounded bg-muted px-2 py-1 text-xs">{supplierAddress}</code>
+      {!compact && supplierAddress ? (
+        <div className="min-w-0">
+          <p className="mb-1.5 text-sm font-medium">{t('dealDetail.supplierWalletAddress')}</p>
+          <CopyableCodeLine value={supplierAddress} label={t('dealDetail.supplierWalletAddress')} />
         </div>
-      )}
+      ) : null}
 
-      {indexerEscrow && (
-        <div className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
+      {indexerEscrow ? (
+        <div className="min-w-0 rounded-lg border border-border/60 bg-muted/30 px-3 py-2.5 text-xs text-muted-foreground">
           <p className="font-medium text-foreground">{t('dealDetail.fromIndexer')}</p>
           {indexerEscrow.type ? (
-            <p className="mt-1 capitalize">{indexerEscrow.type.replace('-', ' ')}</p>
+            <p className="mt-1 break-words capitalize">{indexerEscrow.type.replace('-', ' ')}</p>
           ) : null}
-          {indexerEscrow.balance != null && (
-            <p className="mt-1">
+          {indexerEscrow.balance != null ? (
+            <p className="mt-1 break-words">
               {t('dealDetail.balanceLine', { bal: indexerEscrow.balance.toLocaleString() })}
             </p>
-          )}
+          ) : null}
           {indexerEscrow.milestones?.map((m, i) => {
             const amount =
               'amount' in m && m.amount != null ? ` (${m.amount})` : ''
@@ -150,7 +195,10 @@ export function DealOnChainPanel({
                 ? Boolean((m.flags as { released?: boolean }).released)
                 : false
             return (
-              <p key={`indexer-milestone-${i}-${m.status ?? ''}`} className="mt-0.5">
+              <p
+                key={`indexer-milestone-${i}-${m.status ?? ''}`}
+                className="mt-0.5 break-words"
+              >
                 {t('dealDetail.indexerMilestoneLine', {
                   i,
                   status: released ? 'released' : (m.status ?? '—'),
@@ -160,7 +208,7 @@ export function DealOnChainPanel({
             )
           })}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the **Información en cadena** (On-chain) tab on deal/order detail pages so it renders correctly on mobile screens.

## Problem

On narrow viewports, the on-chain section had several layout issues:
- Escrow contract row used `justify-end`, pushing the address and TrustlessWork button off the right edge
- Long transaction hashes and addresses overflowed without wrapping
- Description text was truncated instead of wrapping
- Action buttons competed for horizontal space with full-length identifiers

## Solution

- Refactored `DealOnChainPanel` to stack identifiers above action buttons (vertical layout)
- Reused `CopyableCodeLine` for full hashes/addresses with `break-all` wrapping and a copy button
- Added `min-w-0` and `break-words` on containers to prevent flex overflow
- Replaced the icon-only Stellar Expert escrow link with a labeled button for clarity on small screens
- Added `min-w-0` to the on-chain tab card content wrapper

## Files changed

- `components/deals/deal-on-chain-panel.tsx`
- `components/deals/deal-detail-tabs.tsx`

## Test plan

- [x] `npm run build` passes
- [ ] Open a funded deal on mobile (or narrow browser width) → On-chain tab
- [ ] Verify escrow address, tx hash, and wallet addresses wrap within the screen
- [ ] Verify TrustlessWork and Stellar Expert buttons appear below identifiers and remain tappable
- [ ] Verify copy buttons work for addresses and hashes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd5c8-9206-7f1f-9fcb-af31101c94c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd5c8-9206-7f1f-9fcb-af31101c94c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

