### PR TITLE
Add social media links to event page footer

### DIFF
--- a/components/events/event-footer.tsx
+++ b/components/events/event-footer.tsx
@@ -1,7 +1,26 @@
 'use client'
 
 import Link from 'next/link'
+import { Linkedin } from 'lucide-react'
 import { useI18n } from '@/lib/i18n/provider'
+
+const SOCIAL_LINKS = {
+  x: 'https://x.com/mercatoweb3',
+  linkedin: 'https://www.linkedin.com/company/mercato-capital/',
+} as const
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden
+    >
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
 
 export function EventFooter() {
   const { t } = useI18n()
@@ -10,6 +29,26 @@ export function EventFooter() {
     <footer className="border-t border-border/60 bg-muted/30 py-10">
       <div className="container mx-auto flex flex-col items-center gap-3 px-4 text-center text-sm text-muted-foreground">
         <p className="font-medium text-foreground">MERCATO</p>
+        <div className="flex items-center justify-center gap-3">
+          <a
+            href={SOCIAL_LINKS.x}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 text-muted-foreground transition-colors hover:border-brand-mid/30 hover:text-foreground"
+            aria-label={t('events.common.footerX')}
+          >
+            <XIcon className="h-4 w-4" />
+          </a>
+          <a
+            href={SOCIAL_LINKS.linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/60 text-muted-foreground transition-colors hover:border-brand-mid/30 hover:text-foreground"
+            aria-label={t('events.common.footerLinkedIn')}
+          >
+            <Linkedin className="h-4 w-4" aria-hidden />
+          </a>
+        </div>
         <div className="flex flex-wrap items-center justify-center gap-4">
           <Link href="https://mercatocapital.xyz" className="underline-offset-4 hover:underline">
             {t('events.common.footerHome')}

--- a/messages/en.json
+++ b/messages/en.json
@@ -2435,6 +2435,8 @@
     "common": {
       "footerHome": "Visit mercatocapital.xyz",
       "footerHowItWorks": "How it works",
+      "footerX": "Follow MERCATO on X",
+      "footerLinkedIn": "Follow MERCATO on LinkedIn",
       "scrollToForm": "Tell us about your business",
       "formTitle": "Tell us how your business works",
       "formSubtitle": "A few quick steps — we want to learn from you, not pitch.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2435,6 +2435,8 @@
     "common": {
       "footerHome": "Visitar mercatocapital.xyz",
       "footerHowItWorks": "Cómo funciona",
+      "footerX": "Seguir a MERCATO en X",
+      "footerLinkedIn": "Seguir a MERCATO en LinkedIn",
       "scrollToForm": "Cuéntanos sobre tu negocio",
       "formTitle": "Cuéntanos cómo funciona tu negocio",
       "formSubtitle": "Unos pasos rápidos — queremos aprender de vos, no venderte.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds MERCATO's X and LinkedIn profiles to the shared event page footer, so the Meetup Argentina landing page (`/events/meetup-argentina`) includes social links.

## Changes

- Added icon links for [X](https://x.com/mercatoweb3) and [LinkedIn](https://www.linkedin.com/company/mercato-capital/) in `EventFooter`
- Added English and Spanish aria-label translations for accessibility

## Test plan

- [ ] Visit `/events/meetup-argentina` and confirm X and LinkedIn icons appear in the footer
- [ ] Verify both links open the correct profiles in a new tab
- [ ] Confirm aria-labels work in both English and Spanish
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd7aa-c081-75bd-975d-642dab686172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd7aa-c081-75bd-975d-642dab686172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

