### PR TITLE
fix: optimize Next.js image delivery and remove global unoptimized setting

### DIFF
--- a/components/landing/landing-hero.tsx
+++ b/components/landing/landing-hero.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import { HeroHowItWorksSteps } from '@/components/landing/hero-how-it-works-steps'
 import { HeroStatsBar } from '@/components/landing/hero-stats-bar'
 import type { LandingPlatformStats } from '@/lib/landing/platform-stats'
@@ -21,13 +22,13 @@ export function LandingHero({ stats }: LandingHeroProps) {
   return (
     <section className="hero-ref relative overflow-x-clip bg-landing-hero text-foreground dark:bg-[hsl(0_0%_4%)] dark:text-white transition-colors duration-500">
       <div className="relative isolate overflow-hidden bg-[hsl(0_0%_5%)]">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
+        <Image
           src="/hero-photo.png"
           alt=""
+          fill
+          sizes="100vw"
+          priority
           className="absolute inset-0 h-full w-full object-cover object-[60%_center]"
-          decoding="async"
-          fetchPriority="high"
           aria-hidden
         />
         <div className="absolute inset-0 bg-gradient-to-r from-black/55 via-black/35 to-black/5" aria-hidden />

--- a/components/media/product-image.tsx
+++ b/components/media/product-image.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import { useState } from 'react'
+import Image from 'next/image'
 import { Package } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const sizeStyles = {
-  xs: { box: 'h-8 w-8 shrink-0 rounded-md', icon: 'h-3.5 w-3.5' },
-  sm: { box: 'h-10 w-10 shrink-0 rounded-lg', icon: 'h-4 w-4' },
-  md: { box: 'h-16 w-16 shrink-0 rounded-xl', icon: 'h-6 w-6' },
-  cover: { box: 'h-40 w-full shrink-0 rounded-none', icon: 'h-10 w-10' },
+  xs: { box: 'h-8 w-8 shrink-0 rounded-md', icon: 'h-3.5 w-3.5', width: 32, height: 32, sizes: '32px' },
+  sm: { box: 'h-10 w-10 shrink-0 rounded-lg', icon: 'h-4 w-4', width: 40, height: 40, sizes: '40px' },
+  md: { box: 'h-16 w-16 shrink-0 rounded-xl', icon: 'h-6 w-6', width: 64, height: 64, sizes: '64px' },
+  cover: { box: 'h-40 w-full shrink-0 rounded-none', icon: 'h-10 w-10', width: 0, height: 0, sizes: '100vw' },
 } as const
 
 type ProductImageProps = {
@@ -37,12 +38,26 @@ export function ProductImage({
       )}
     >
       {showImage ? (
-        <img
-          src={imageUrl!}
-          alt={alt}
-          className="h-full w-full object-cover"
-          onError={() => setImageError(true)}
-        />
+        size === 'cover' ? (
+          <Image
+            src={imageUrl!}
+            alt={alt}
+            fill
+            sizes={styles.sizes}
+            className="h-full w-full object-cover"
+            onError={() => setImageError(true)}
+          />
+        ) : (
+          <Image
+            src={imageUrl!}
+            alt={alt}
+            width={styles.width}
+            height={styles.height}
+            sizes={styles.sizes}
+            className="h-full w-full object-cover"
+            onError={() => setImageError(true)}
+          />
+        )
       ) : (
         <Package className={cn('text-muted-foreground/50', styles.icon)} aria-hidden />
       )}

--- a/components/suppliers/supplier-logo.tsx
+++ b/components/suppliers/supplier-logo.tsx
@@ -1,14 +1,15 @@
 'use client'
 
 import { useState } from 'react'
+import Image from 'next/image'
 import { Building2, type LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 const sizeStyles = {
-  xs: { box: 'h-5 w-5 rounded', icon: 'h-3 w-3' },
-  sm: { box: 'h-10 w-10 rounded-lg', icon: 'h-5 w-5' },
-  md: { box: 'h-12 w-12 rounded-xl', icon: 'h-6 w-6' },
-  lg: { box: 'h-16 w-16 rounded-2xl', icon: 'h-8 w-8' },
+  xs: { box: 'h-5 w-5 rounded', icon: 'h-3 w-3', width: 20, height: 20, sizes: '20px' },
+  sm: { box: 'h-10 w-10 rounded-lg', icon: 'h-5 w-5', width: 40, height: 40, sizes: '40px' },
+  md: { box: 'h-12 w-12 rounded-xl', icon: 'h-6 w-6', width: 48, height: 48, sizes: '48px' },
+  lg: { box: 'h-16 w-16 rounded-2xl', icon: 'h-8 w-8', width: 64, height: 64, sizes: '64px' },
 } as const
 
 type SupplierLogoProps = {
@@ -39,9 +40,12 @@ export function SupplierLogo({
       )}
     >
       {showLogo ? (
-        <img
+        <Image
           src={logoUrl!}
           alt={companyName}
+          width={styles.width}
+          height={styles.height}
+          sizes={styles.sizes}
           className="h-full w-full object-cover"
           onError={() => setImageError(true)}
         />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,13 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+        pathname: '/storage/v1/object/public/**',
+      },
+    ],
   },
   experimental: {
     optimizePackageImports: [


### PR DESCRIPTION
## Summary

Restore optimized image delivery for application images by removing the global `images.unoptimized: true` setting and migrating raw `<img>` elements to `next/image`.

## Changes

- **next.config.mjs**: Removed `images.unoptimized: true`, added `remotePatterns` for `*.supabase.co`
- **landing-hero.tsx**: Migrated to `<Image>` with `fill`, `sizes="100vw"`, and `priority` for LCP
- **product-image.tsx**: Migrated to `<Image>` with responsive `sizes` per variant
- **supplier-logo.tsx**: Migrated to `<Image>` with responsive `sizes` per variant

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Hero image | ~2MB PNG | ~150-300KB AVIF/WebP |
| Product images | Original size | Responsive variants |
| Logo images | Original size | Responsive variants |

## Acceptance Criteria

- [x] Production content images use Next.js optimization and responsive sizing
- [x] Landing hero no longer transfers the original raster file
- [x] Remote image hosts are allowlisted explicitly
- [x] Configuration does not disable optimization globally
- [x] No preventable layout shift from migrated images

## Verification

- [x] `bun lint` — No new errors
- [x] `bun build` — Build successful
- [x] `bun test` — 191 tests pass

Closes #173
