### PR TITLE
Refactor supplier commercial activity page into reusable units

### DIFF
--- a/__tests__/components/supplier-activity/pagination-controls.test.tsx
+++ b/__tests__/components/supplier-activity/pagination-controls.test.tsx
@@ -1,0 +1,79 @@
+import { test, expect, afterEach, mock } from 'bun:test'
+import React from 'react'
+import { render, screen, cleanup } from '@testing-library/react'
+import { SupplierActivityPaginationControls } from '@/components/supplier-activity/pagination-controls'
+
+mock.module('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+afterEach(() => {
+  mock.restore()
+  cleanup()
+})
+
+const labels = {
+  prevPage: 'Previous',
+  nextPage: 'Next',
+  pagination: 'Page {page} of {total}',
+}
+
+test('renders nothing when there is only one page', () => {
+  const { container } = render(
+    <SupplierActivityPaginationControls
+      page={1}
+      totalPages={1}
+      filterQuery={{}}
+      labels={labels}
+    />,
+  )
+  expect(container.firstChild).toBeNull()
+})
+
+test('shows only Next on the first page', () => {
+  render(
+    <SupplierActivityPaginationControls
+      page={1}
+      totalPages={3}
+      filterQuery={{}}
+      labels={labels}
+    />,
+  )
+  expect(screen.getByText('Page 1 of 3')).toBeTruthy()
+  expect(screen.getByRole('link', { name: 'Next' })).toBeTruthy()
+  expect(screen.queryByRole('link', { name: 'Previous' })).toBeNull()
+})
+
+test('shows only Previous on the last page', () => {
+  render(
+    <SupplierActivityPaginationControls
+      page={3}
+      totalPages={3}
+      filterQuery={{}}
+      labels={labels}
+    />,
+  )
+  expect(screen.getByRole('link', { name: 'Previous' })).toBeTruthy()
+  expect(screen.queryByRole('link', { name: 'Next' })).toBeNull()
+})
+
+test('preserves filters in the generated links', () => {
+  render(
+    <SupplierActivityPaginationControls
+      page={2}
+      totalPages={3}
+      filterQuery={{ company: 'company-1', status: 'needs_shipment' }}
+      labels={labels}
+    />,
+  )
+  const prevLink = screen.getByRole('link', { name: 'Previous' }) as HTMLAnchorElement
+  const nextLink = screen.getByRole('link', { name: 'Next' }) as HTMLAnchorElement
+  expect(prevLink.getAttribute('href')).toBe(
+    '/dashboard/supplier-activity?company=company-1&status=needs_shipment',
+  )
+  expect(nextLink.getAttribute('href')).toBe(
+    '/dashboard/supplier-activity?company=company-1&status=needs_shipment&page=3',
+  )
+})

--- a/__tests__/suppliers/supplier-activity-authorization.test.ts
+++ b/__tests__/suppliers/supplier-activity-authorization.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { authorizeSupplierActivityAccess } from '@/lib/suppliers/supplier-activity-authorization'
+
+function mockSupabase(user: { id: string } | null, userType: string | null) {
+  return {
+    auth: {
+      getUser: async () => ({ data: { user } }),
+    },
+    from: (_table: string) => ({
+      select: (_cols: string) => ({
+        eq: (_col: string, _val: string) => ({
+          single: async () => ({ data: userType ? { user_type: userType } : null }),
+        }),
+      }),
+    }),
+  } as unknown as SupabaseClient
+}
+
+describe('authorizeSupplierActivityAccess', () => {
+  test('returns unauthenticated when there is no session user', async () => {
+    const result = await authorizeSupplierActivityAccess(mockSupabase(null, null))
+    expect(result).toEqual({ status: 'unauthenticated' })
+  })
+
+  test('returns unauthorized when the profile is not a supplier', async () => {
+    const result = await authorizeSupplierActivityAccess(mockSupabase({ id: 'user-1' }, 'pyme'))
+    expect(result).toEqual({ status: 'unauthorized' })
+  })
+
+  test('returns unauthorized when the profile is missing', async () => {
+    const result = await authorizeSupplierActivityAccess(mockSupabase({ id: 'user-1' }, null))
+    expect(result).toEqual({ status: 'unauthorized' })
+  })
+
+  test('returns authorized with the user id for a supplier profile', async () => {
+    const result = await authorizeSupplierActivityAccess(
+      mockSupabase({ id: 'user-1' }, 'supplier'),
+    )
+    expect(result).toEqual({ status: 'authorized', userId: 'user-1' })
+  })
+})

--- a/__tests__/suppliers/supplier-activity-labels.test.ts
+++ b/__tests__/suppliers/supplier-activity-labels.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { getDictionary } from '@/lib/i18n/dictionaries'
+import {
+  buildActivityTableLabels,
+  buildCustomerActivityTableLabels,
+  buildFiltersFormLabels,
+  buildPaginationLabels,
+  buildProductPerformanceTableLabels,
+  buildSummaryCardLabels,
+  getSupplierActivityStateLabels,
+} from '@/lib/suppliers/supplier-activity-labels'
+
+const m = getDictionary('en').supplierActivity
+
+describe('supplier-activity-labels', () => {
+  test('getSupplierActivityStateLabels returns the states map', () => {
+    expect(getSupplierActivityStateLabels(m)).toBe(m.states)
+    expect(getSupplierActivityStateLabels(m).needs_shipment).toBe(m.states.needs_shipment)
+  })
+
+  test('buildSummaryCardLabels maps the five summary fields', () => {
+    expect(buildSummaryCardLabels(m)).toEqual({
+      openRequests: m.summary.openRequests,
+      activeFinanced: m.summary.activeFinanced,
+      completedFinanced: m.summary.completedFinanced,
+      pendingShipments: m.summary.pendingShipments,
+      totalVolume: m.summary.totalVolume,
+    })
+  })
+
+  test('buildFiltersFormLabels maps filter and action labels', () => {
+    const labels = buildFiltersFormLabels(m)
+    expect(labels.company).toBe(m.filters.company)
+    expect(labels.apply).toBe(m.filters.apply)
+    expect(labels.clear).toBe(m.filters.clear)
+  })
+
+  test('buildActivityTableLabels reuses the shared table labels and activity title/empty text', () => {
+    const labels = buildActivityTableLabels(m)
+    expect(labels.title).toBe(m.activityTitle)
+    expect(labels.empty).toBe(m.activityEmpty)
+    expect(labels.product).toBe(m.table.product)
+    expect(labels.viewDeal).toBe(m.table.viewDeal)
+  })
+
+  test('buildPaginationLabels maps pagination text', () => {
+    expect(buildPaginationLabels(m)).toEqual({
+      prevPage: m.prevPage,
+      nextPage: m.nextPage,
+      pagination: m.pagination,
+    })
+  })
+
+  test('buildProductPerformanceTableLabels reuses shared table labels', () => {
+    const labels = buildProductPerformanceTableLabels(m)
+    expect(labels.title).toBe(m.productPerformanceTitle)
+    expect(labels.empty).toBe(m.productPerformanceEmpty)
+    expect(labels.category).toBe(m.table.category)
+  })
+
+  test('buildCustomerActivityTableLabels reuses shared customer label and empty text', () => {
+    const labels = buildCustomerActivityTableLabels(m)
+    expect(labels.title).toBe(m.customerActivityTitle)
+    expect(labels.empty).toBe(m.customerActivityEmpty)
+    expect(labels.customer).toBe(m.table.customer)
+  })
+})

--- a/__tests__/suppliers/supplier-activity-params.test.ts
+++ b/__tests__/suppliers/supplier-activity-params.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test'
+import { parseSupplierActivityParams } from '@/lib/suppliers/supplier-activity-params'
+
+describe('parseSupplierActivityParams', () => {
+  test('returns undefined fields and page 1 for an empty params object', () => {
+    const result = parseSupplierActivityParams({})
+    expect(result).toEqual({
+      companyId: undefined,
+      productId: undefined,
+      category: undefined,
+      commercialStatus: undefined,
+      dateFrom: undefined,
+      dateTo: undefined,
+      dateFromISO: undefined,
+      dateToISO: undefined,
+      page: 1,
+    })
+  })
+
+  test('trims and passes through company, product, and category', () => {
+    const result = parseSupplierActivityParams({
+      company: '  company-1  ',
+      product: '  product-1  ',
+      category: '  Textiles  ',
+    })
+    expect(result.companyId).toBe('company-1')
+    expect(result.productId).toBe('product-1')
+    expect(result.category).toBe('Textiles')
+  })
+
+  test('treats blank strings as undefined', () => {
+    const result = parseSupplierActivityParams({ company: '   ', product: '' })
+    expect(result.companyId).toBeUndefined()
+    expect(result.productId).toBeUndefined()
+  })
+
+  test('accepts a valid commercial status', () => {
+    const result = parseSupplierActivityParams({ status: 'needs_shipment' })
+    expect(result.commercialStatus).toBe('needs_shipment')
+  })
+
+  test('rejects an invalid commercial status', () => {
+    const result = parseSupplierActivityParams({ status: 'not-a-real-status' })
+    expect(result.commercialStatus).toBeUndefined()
+  })
+
+  test('converts date range to start/end-of-day ISO instants while keeping raw values', () => {
+    const result = parseSupplierActivityParams({ dateFrom: '2026-01-01', dateTo: '2026-01-31' })
+    expect(result.dateFrom).toBe('2026-01-01')
+    expect(result.dateTo).toBe('2026-01-31')
+    expect(result.dateFromISO).toBe('2026-01-01T00:00:00.000Z')
+    expect(result.dateToISO).toBe('2026-01-31T23:59:59.999Z')
+  })
+
+  test('clamps page to a minimum of 1', () => {
+    expect(parseSupplierActivityParams({ page: '0' }).page).toBe(1)
+    expect(parseSupplierActivityParams({ page: '-5' }).page).toBe(1)
+  })
+
+  test('falls back to page 1 for a non-numeric page', () => {
+    expect(parseSupplierActivityParams({ page: 'abc' }).page).toBe(1)
+  })
+
+  test('parses a valid page number', () => {
+    expect(parseSupplierActivityParams({ page: '3' }).page).toBe(3)
+  })
+})

--- a/__tests__/suppliers/supplier-activity-url.test.ts
+++ b/__tests__/suppliers/supplier-activity-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test'
+import { buildSupplierActivityHref } from '@/lib/suppliers/supplier-activity-url'
+
+describe('buildSupplierActivityHref', () => {
+  test('returns the bare path when there are no filters and page is 1', () => {
+    expect(buildSupplierActivityHref({}, 1)).toBe('/dashboard/supplier-activity')
+  })
+
+  test('omits the page param when page is 1', () => {
+    expect(buildSupplierActivityHref({ company: 'company-1' }, 1)).toBe(
+      '/dashboard/supplier-activity?company=company-1',
+    )
+  })
+
+  test('includes the page param when page is greater than 1', () => {
+    expect(buildSupplierActivityHref({}, 2)).toBe('/dashboard/supplier-activity?page=2')
+  })
+
+  test('includes only truthy filter values, in insertion order', () => {
+    const href = buildSupplierActivityHref(
+      {
+        company: 'company-1',
+        product: undefined,
+        category: 'Textiles',
+        status: '',
+        dateFrom: '2026-01-01',
+        dateTo: undefined,
+      },
+      3,
+    )
+    expect(href).toBe(
+      '/dashboard/supplier-activity?company=company-1&category=Textiles&dateFrom=2026-01-01&page=3',
+    )
+  })
+})

--- a/app/dashboard/supplier-activity/page.tsx
+++ b/app/dashboard/supplier-activity/page.tsx
@@ -1,93 +1,51 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
 import { getServerDictionary } from '@/lib/i18n/server'
 import { getSupplierCommercialActivity } from '@/lib/suppliers/get-supplier-commercial-activity'
-import type { SupplierCommercialState } from '@/lib/suppliers/commercial-states'
+import { authorizeSupplierActivityAccess } from '@/lib/suppliers/supplier-activity-authorization'
+import {
+  parseSupplierActivityParams,
+  type SupplierActivityRawParams,
+} from '@/lib/suppliers/supplier-activity-params'
+import { SUPPLIER_COMMERCIAL_STATES } from '@/lib/suppliers/commercial-states'
+import {
+  buildActivityTableLabels,
+  buildCustomerActivityTableLabels,
+  buildFiltersFormLabels,
+  buildPaginationLabels,
+  buildProductPerformanceTableLabels,
+  buildSummaryCardLabels,
+  getSupplierActivityStateLabels,
+} from '@/lib/suppliers/supplier-activity-labels'
 import { SupplierActivitySummaryCards } from '@/components/supplier-activity/summary-cards'
 import { SupplierActivityFiltersForm } from '@/components/supplier-activity/filters-form'
-import { SupplierActivityTable } from '@/components/supplier-activity/activity-table'
-import { ProductPerformanceTable } from '@/components/supplier-activity/product-performance-table'
-import { CustomerActivityTable } from '@/components/supplier-activity/customer-activity-table'
-import { Button } from '@/components/ui/button'
-
-const COMMERCIAL_STATES: SupplierCommercialState[] = [
-  'financing_request',
-  'expired',
-  'cancelled',
-  'financed_sale',
-  'needs_shipment',
-  'in_fulfillment',
-  'completed_sale',
-]
+import { SupplierActivitySection } from '@/components/supplier-activity/activity-section'
+import { SupplierProductPerformanceSection } from '@/components/supplier-activity/product-performance-section'
+import { SupplierCustomerActivitySection } from '@/components/supplier-activity/customer-activity-section'
 
 type PageProps = {
-  searchParams: Promise<{
-    company?: string
-    product?: string
-    category?: string
-    status?: string
-    dateFrom?: string
-    dateTo?: string
-    page?: string
-  }>
-}
-
-function buildPageHref(
-  base: Record<string, string | undefined>,
-  page: number,
-): string {
-  const params = new URLSearchParams()
-  for (const [key, value] of Object.entries(base)) {
-    if (value) params.set(key, value)
-  }
-  if (page > 1) params.set('page', String(page))
-  const qs = params.toString()
-  return qs ? `/dashboard/supplier-activity?${qs}` : '/dashboard/supplier-activity'
+  searchParams: Promise<SupplierActivityRawParams>
 }
 
 export default async function SupplierActivityPage({ searchParams }: PageProps) {
   const m = await getServerDictionary()
-  const params = await searchParams
+  const rawParams = await searchParams
   const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
 
-  if (!user) redirect('/auth/login')
+  const auth = await authorizeSupplierActivityAccess(supabase)
+  if (auth.status === 'unauthenticated') redirect('/auth/login')
+  if (auth.status === 'unauthorized') redirect('/dashboard')
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('user_type')
-    .eq('id', user.id)
-    .single()
+  const filters = parseSupplierActivityParams(rawParams)
 
-  if (profile?.user_type !== 'supplier') {
-    redirect('/dashboard')
-  }
-
-  const companyId = params.company?.trim() || undefined
-  const productId = params.product?.trim() || undefined
-  const category = params.category?.trim() || undefined
-  const commercialStatus = COMMERCIAL_STATES.includes(params.status as SupplierCommercialState)
-    ? (params.status as SupplierCommercialState)
-    : undefined
-  const dateFrom = params.dateFrom
-    ? new Date(`${params.dateFrom}T00:00:00.000Z`).toISOString()
-    : undefined
-  const dateTo = params.dateTo
-    ? new Date(`${params.dateTo}T23:59:59.999Z`).toISOString()
-    : undefined
-  const page = Math.max(1, Number.parseInt(params.page ?? '1', 10) || 1)
-
-  const data = await getSupplierCommercialActivity(supabase, user.id, {
-    companyId,
-    productId,
-    category,
-    commercialStatus,
-    dateFrom,
-    dateTo,
-    page,
+  const data = await getSupplierCommercialActivity(supabase, auth.userId, {
+    companyId: filters.companyId,
+    productId: filters.productId,
+    category: filters.category,
+    commercialStatus: filters.commercialStatus,
+    dateFrom: filters.dateFromISO,
+    dateTo: filters.dateToISO,
+    page: filters.page,
     pageSize: 20,
   })
 
@@ -99,18 +57,18 @@ export default async function SupplierActivityPage({ searchParams }: PageProps) 
     )
   }
 
-  const stateLabels = m.supplierActivity.states as Record<SupplierCommercialState, string>
+  const stateLabels = getSupplierActivityStateLabels(m.supplierActivity)
   const categories = Array.from(
     new Set(data.filterProducts.map((p) => p.category).filter(Boolean)),
   ).sort()
 
-  const filterBase = {
-    company: companyId,
-    product: productId,
-    category,
-    status: commercialStatus,
-    dateFrom: params.dateFrom,
-    dateTo: params.dateTo,
+  const filterQuery = {
+    company: filters.companyId,
+    product: filters.productId,
+    category: filters.category,
+    status: filters.commercialStatus,
+    dateFrom: filters.dateFrom,
+    dateTo: filters.dateTo,
   }
 
   const totalPages = Math.max(1, Math.ceil(data.activityTotal / data.pageSize))
@@ -124,126 +82,48 @@ export default async function SupplierActivityPage({ searchParams }: PageProps) 
 
       <SupplierActivitySummaryCards
         summary={data.summary}
-        labels={{
-          openRequests: m.supplierActivity.summary.openRequests,
-          activeFinanced: m.supplierActivity.summary.activeFinanced,
-          completedFinanced: m.supplierActivity.summary.completedFinanced,
-          pendingShipments: m.supplierActivity.summary.pendingShipments,
-          totalVolume: m.supplierActivity.summary.totalVolume,
-        }}
+        labels={buildSummaryCardLabels(m.supplierActivity)}
       />
 
       <SupplierActivityFiltersForm
         companies={data.companies}
         products={data.filterProducts}
         categories={categories}
-        commercialStates={COMMERCIAL_STATES}
+        commercialStates={SUPPLIER_COMMERCIAL_STATES}
         stateLabels={stateLabels}
-        labels={{
-          company: m.supplierActivity.filters.company,
-          product: m.supplierActivity.filters.product,
-          category: m.supplierActivity.filters.category,
-          status: m.supplierActivity.filters.status,
-          dateFrom: m.supplierActivity.filters.dateFrom,
-          dateTo: m.supplierActivity.filters.dateTo,
-          all: m.supplierActivity.filters.all,
-          apply: m.supplierActivity.filters.apply,
-          clear: m.supplierActivity.filters.clear,
-        }}
+        labels={buildFiltersFormLabels(m.supplierActivity)}
         values={{
-          companyId,
-          productId,
-          category,
-          commercialStatus,
-          dateFrom: params.dateFrom,
-          dateTo: params.dateTo,
+          companyId: filters.companyId,
+          productId: filters.productId,
+          category: filters.category,
+          commercialStatus: filters.commercialStatus,
+          dateFrom: filters.dateFrom,
+          dateTo: filters.dateTo,
         }}
       />
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">{m.supplierActivity.activityTitle}</h2>
-        <SupplierActivityTable
-          items={data.activity}
-          stateLabels={stateLabels}
-          labels={{
-            title: m.supplierActivity.activityTitle,
-            product: m.supplierActivity.table.product,
-            customer: m.supplierActivity.table.customer,
-            company: m.supplierActivity.table.company,
-            amount: m.supplierActivity.table.amount,
-            quantity: m.supplierActivity.table.quantity,
-            unitPrice: m.supplierActivity.table.unitPrice,
-            status: m.supplierActivity.table.status,
-            investor: m.supplierActivity.table.investor,
-            created: m.supplierActivity.table.created,
-            funded: m.supplierActivity.table.funded,
-            shipped: m.supplierActivity.table.shipped,
-            viewDeal: m.supplierActivity.table.viewDeal,
-            empty: m.supplierActivity.activityEmpty,
-          }}
-        />
-        {totalPages > 1 && (
-          <div className="flex items-center justify-between gap-4">
-            <p className="text-sm text-muted-foreground">
-              {m.supplierActivity.pagination
-                .replace('{page}', String(page))
-                .replace('{total}', String(totalPages))}
-            </p>
-            <div className="flex gap-2">
-              {page > 1 && (
-                <Button variant="outline" size="sm" asChild>
-                  <Link href={buildPageHref(filterBase, page - 1)}>
-                    {m.supplierActivity.prevPage}
-                  </Link>
-                </Button>
-              )}
-              {page < totalPages && (
-                <Button variant="outline" size="sm" asChild>
-                  <Link href={buildPageHref(filterBase, page + 1)}>
-                    {m.supplierActivity.nextPage}
-                  </Link>
-                </Button>
-              )}
-            </div>
-          </div>
-        )}
-      </section>
+      <SupplierActivitySection
+        sectionTitle={m.supplierActivity.activityTitle}
+        items={data.activity}
+        stateLabels={stateLabels}
+        tableLabels={buildActivityTableLabels(m.supplierActivity)}
+        page={filters.page}
+        totalPages={totalPages}
+        filterQuery={filterQuery}
+        paginationLabels={buildPaginationLabels(m.supplierActivity)}
+      />
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">{m.supplierActivity.productPerformanceTitle}</h2>
-        <ProductPerformanceTable
-          items={data.productPerformance}
-          labels={{
-            title: m.supplierActivity.productPerformanceTitle,
-            product: m.supplierActivity.table.product,
-            category: m.supplierActivity.table.category,
-            requests: m.supplierActivity.productPerformance.requests,
-            funded: m.supplierActivity.productPerformance.funded,
-            conversion: m.supplierActivity.productPerformance.conversion,
-            financedVolume: m.supplierActivity.productPerformance.financedVolume,
-            completedVolume: m.supplierActivity.productPerformance.completedVolume,
-            empty: m.supplierActivity.productPerformanceEmpty,
-          }}
-        />
-      </section>
+      <SupplierProductPerformanceSection
+        sectionTitle={m.supplierActivity.productPerformanceTitle}
+        items={data.productPerformance}
+        labels={buildProductPerformanceTableLabels(m.supplierActivity)}
+      />
 
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">{m.supplierActivity.customerActivityTitle}</h2>
-        <CustomerActivityTable
-          items={data.customerActivity}
-          labels={{
-            title: m.supplierActivity.customerActivityTitle,
-            customer: m.supplierActivity.table.customer,
-            products: m.supplierActivity.customerActivity.products,
-            requests: m.supplierActivity.customerActivity.requests,
-            requestValue: m.supplierActivity.customerActivity.requestValue,
-            funded: m.supplierActivity.customerActivity.funded,
-            awaiting: m.supplierActivity.customerActivity.awaiting,
-            lastActivity: m.supplierActivity.customerActivity.lastActivity,
-            empty: m.supplierActivity.customerActivityEmpty,
-          }}
-        />
-      </section>
+      <SupplierCustomerActivitySection
+        sectionTitle={m.supplierActivity.customerActivityTitle}
+        items={data.customerActivity}
+        labels={buildCustomerActivityTableLabels(m.supplierActivity)}
+      />
     </div>
   )
 }

--- a/components/supplier-activity/activity-section.tsx
+++ b/components/supplier-activity/activity-section.tsx
@@ -1,0 +1,44 @@
+import { SupplierActivityTable } from './activity-table'
+import { SupplierActivityPaginationControls } from './pagination-controls'
+import type { SupplierCommercialActivityItem } from '@/lib/suppliers/get-supplier-commercial-activity'
+import type { SupplierCommercialState } from '@/lib/suppliers/commercial-states'
+import type { SupplierActivityFilterQuery } from '@/lib/suppliers/supplier-activity-url'
+import type {
+  buildActivityTableLabels,
+  buildPaginationLabels,
+} from '@/lib/suppliers/supplier-activity-labels'
+
+type ActivitySectionProps = {
+  sectionTitle: string
+  items: SupplierCommercialActivityItem[]
+  stateLabels: Record<SupplierCommercialState, string>
+  tableLabels: ReturnType<typeof buildActivityTableLabels>
+  page: number
+  totalPages: number
+  filterQuery: SupplierActivityFilterQuery
+  paginationLabels: ReturnType<typeof buildPaginationLabels>
+}
+
+export function SupplierActivitySection({
+  sectionTitle,
+  items,
+  stateLabels,
+  tableLabels,
+  page,
+  totalPages,
+  filterQuery,
+  paginationLabels,
+}: ActivitySectionProps) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">{sectionTitle}</h2>
+      <SupplierActivityTable items={items} stateLabels={stateLabels} labels={tableLabels} />
+      <SupplierActivityPaginationControls
+        page={page}
+        totalPages={totalPages}
+        filterQuery={filterQuery}
+        labels={paginationLabels}
+      />
+    </section>
+  )
+}

--- a/components/supplier-activity/customer-activity-section.tsx
+++ b/components/supplier-activity/customer-activity-section.tsx
@@ -1,0 +1,22 @@
+import { CustomerActivityTable } from './customer-activity-table'
+import type { SupplierCustomerActivity } from '@/lib/suppliers/get-supplier-commercial-activity'
+import type { buildCustomerActivityTableLabels } from '@/lib/suppliers/supplier-activity-labels'
+
+type CustomerActivitySectionProps = {
+  sectionTitle: string
+  items: SupplierCustomerActivity[]
+  labels: ReturnType<typeof buildCustomerActivityTableLabels>
+}
+
+export function SupplierCustomerActivitySection({
+  sectionTitle,
+  items,
+  labels,
+}: CustomerActivitySectionProps) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">{sectionTitle}</h2>
+      <CustomerActivityTable items={items} labels={labels} />
+    </section>
+  )
+}

--- a/components/supplier-activity/pagination-controls.tsx
+++ b/components/supplier-activity/pagination-controls.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import {
+  buildSupplierActivityHref,
+  type SupplierActivityFilterQuery,
+} from '@/lib/suppliers/supplier-activity-url'
+import type { buildPaginationLabels } from '@/lib/suppliers/supplier-activity-labels'
+
+type PaginationControlsProps = {
+  page: number
+  totalPages: number
+  filterQuery: SupplierActivityFilterQuery
+  labels: ReturnType<typeof buildPaginationLabels>
+}
+
+export function SupplierActivityPaginationControls({
+  page,
+  totalPages,
+  filterQuery,
+  labels,
+}: PaginationControlsProps) {
+  if (totalPages <= 1) return null
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <p className="text-sm text-muted-foreground">
+        {labels.pagination.replace('{page}', String(page)).replace('{total}', String(totalPages))}
+      </p>
+      <div className="flex gap-2">
+        {page > 1 && (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={buildSupplierActivityHref(filterQuery, page - 1)}>
+              {labels.prevPage}
+            </Link>
+          </Button>
+        )}
+        {page < totalPages && (
+          <Button variant="outline" size="sm" asChild>
+            <Link href={buildSupplierActivityHref(filterQuery, page + 1)}>
+              {labels.nextPage}
+            </Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/supplier-activity/product-performance-section.tsx
+++ b/components/supplier-activity/product-performance-section.tsx
@@ -1,0 +1,22 @@
+import { ProductPerformanceTable } from './product-performance-table'
+import type { SupplierProductPerformance } from '@/lib/suppliers/get-supplier-commercial-activity'
+import type { buildProductPerformanceTableLabels } from '@/lib/suppliers/supplier-activity-labels'
+
+type ProductPerformanceSectionProps = {
+  sectionTitle: string
+  items: SupplierProductPerformance[]
+  labels: ReturnType<typeof buildProductPerformanceTableLabels>
+}
+
+export function SupplierProductPerformanceSection({
+  sectionTitle,
+  items,
+  labels,
+}: ProductPerformanceSectionProps) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold">{sectionTitle}</h2>
+      <ProductPerformanceTable items={items} labels={labels} />
+    </section>
+  )
+}

--- a/lib/suppliers/commercial-states.ts
+++ b/lib/suppliers/commercial-states.ts
@@ -10,6 +10,17 @@ export type SupplierCommercialState =
   | 'in_fulfillment'
   | 'completed_sale'
 
+/** All supplier commercial states, in lifecycle display order. */
+export const SUPPLIER_COMMERCIAL_STATES: SupplierCommercialState[] = [
+  'financing_request',
+  'expired',
+  'cancelled',
+  'financed_sale',
+  'needs_shipment',
+  'in_fulfillment',
+  'completed_sale',
+]
+
 export type SupplierCommercialDealRow = Pick<
   DealRow,
   | 'status'

--- a/lib/suppliers/supplier-activity-authorization.ts
+++ b/lib/suppliers/supplier-activity-authorization.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type SupplierActivityAuthorization =
+  | { status: 'unauthenticated' }
+  | { status: 'unauthorized' }
+  | { status: 'authorized'; userId: string }
+
+/** Resolves whether the current session belongs to an authenticated supplier user. */
+export async function authorizeSupplierActivityAccess(
+  supabase: SupabaseClient,
+): Promise<SupplierActivityAuthorization> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return { status: 'unauthenticated' }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('user_type')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.user_type !== 'supplier') {
+    return { status: 'unauthorized' }
+  }
+
+  return { status: 'authorized', userId: user.id }
+}

--- a/lib/suppliers/supplier-activity-labels.ts
+++ b/lib/suppliers/supplier-activity-labels.ts
@@ -1,0 +1,89 @@
+import type { Messages } from '@/lib/i18n/dictionaries'
+import type { SupplierCommercialState } from './commercial-states'
+
+export type SupplierActivityMessages = Messages['supplierActivity']
+
+export function getSupplierActivityStateLabels(
+  m: SupplierActivityMessages,
+): Record<SupplierCommercialState, string> {
+  return m.states
+}
+
+export function buildSummaryCardLabels(m: SupplierActivityMessages) {
+  return {
+    openRequests: m.summary.openRequests,
+    activeFinanced: m.summary.activeFinanced,
+    completedFinanced: m.summary.completedFinanced,
+    pendingShipments: m.summary.pendingShipments,
+    totalVolume: m.summary.totalVolume,
+  }
+}
+
+export function buildFiltersFormLabels(m: SupplierActivityMessages) {
+  return {
+    company: m.filters.company,
+    product: m.filters.product,
+    category: m.filters.category,
+    status: m.filters.status,
+    dateFrom: m.filters.dateFrom,
+    dateTo: m.filters.dateTo,
+    all: m.filters.all,
+    apply: m.filters.apply,
+    clear: m.filters.clear,
+  }
+}
+
+export function buildActivityTableLabels(m: SupplierActivityMessages) {
+  return {
+    title: m.activityTitle,
+    product: m.table.product,
+    customer: m.table.customer,
+    company: m.table.company,
+    amount: m.table.amount,
+    quantity: m.table.quantity,
+    unitPrice: m.table.unitPrice,
+    status: m.table.status,
+    investor: m.table.investor,
+    created: m.table.created,
+    funded: m.table.funded,
+    shipped: m.table.shipped,
+    viewDeal: m.table.viewDeal,
+    empty: m.activityEmpty,
+  }
+}
+
+export function buildPaginationLabels(m: SupplierActivityMessages) {
+  return {
+    prevPage: m.prevPage,
+    nextPage: m.nextPage,
+    pagination: m.pagination,
+  }
+}
+
+export function buildProductPerformanceTableLabels(m: SupplierActivityMessages) {
+  return {
+    title: m.productPerformanceTitle,
+    product: m.table.product,
+    category: m.table.category,
+    requests: m.productPerformance.requests,
+    funded: m.productPerformance.funded,
+    conversion: m.productPerformance.conversion,
+    financedVolume: m.productPerformance.financedVolume,
+    completedVolume: m.productPerformance.completedVolume,
+    empty: m.productPerformanceEmpty,
+  }
+}
+
+export function buildCustomerActivityTableLabels(m: SupplierActivityMessages) {
+  return {
+    title: m.customerActivityTitle,
+    customer: m.table.customer,
+    products: m.customerActivity.products,
+    requests: m.customerActivity.requests,
+    requestValue: m.customerActivity.requestValue,
+    funded: m.customerActivity.funded,
+    awaiting: m.customerActivity.awaiting,
+    lastActivity: m.customerActivity.lastActivity,
+    empty: m.customerActivityEmpty,
+  }
+}

--- a/lib/suppliers/supplier-activity-params.ts
+++ b/lib/suppliers/supplier-activity-params.ts
@@ -1,0 +1,58 @@
+import { SUPPLIER_COMMERCIAL_STATES, type SupplierCommercialState } from './commercial-states'
+
+export type SupplierActivityRawParams = {
+  company?: string
+  product?: string
+  category?: string
+  status?: string
+  dateFrom?: string
+  dateTo?: string
+  page?: string
+}
+
+export type SupplierActivityParsedParams = {
+  companyId?: string
+  productId?: string
+  category?: string
+  commercialStatus?: SupplierCommercialState
+  dateFrom?: string
+  dateTo?: string
+  dateFromISO?: string
+  dateToISO?: string
+  page: number
+}
+
+function isSupplierCommercialState(
+  value: string | undefined,
+): value is SupplierCommercialState {
+  return SUPPLIER_COMMERCIAL_STATES.includes(value as SupplierCommercialState)
+}
+
+/** Parses and validates raw supplier-activity search params from the URL. */
+export function parseSupplierActivityParams(
+  params: SupplierActivityRawParams,
+): SupplierActivityParsedParams {
+  const companyId = params.company?.trim() || undefined
+  const productId = params.product?.trim() || undefined
+  const category = params.category?.trim() || undefined
+  const commercialStatus = isSupplierCommercialState(params.status) ? params.status : undefined
+  const dateFrom = params.dateFrom
+  const dateTo = params.dateTo
+  const dateFromISO = dateFrom
+    ? new Date(`${dateFrom}T00:00:00.000Z`).toISOString()
+    : undefined
+  const dateToISO = dateTo ? new Date(`${dateTo}T23:59:59.999Z`).toISOString() : undefined
+  const page = Math.max(1, Number.parseInt(params.page ?? '1', 10) || 1)
+
+  return {
+    companyId,
+    productId,
+    category,
+    commercialStatus,
+    dateFrom,
+    dateTo,
+    dateFromISO,
+    dateToISO,
+    page,
+  }
+}

--- a/lib/suppliers/supplier-activity-url.ts
+++ b/lib/suppliers/supplier-activity-url.ts
@@ -1,0 +1,24 @@
+export type SupplierActivityFilterQuery = {
+  company?: string
+  product?: string
+  category?: string
+  status?: string
+  dateFrom?: string
+  dateTo?: string
+}
+
+const SUPPLIER_ACTIVITY_PATH = '/dashboard/supplier-activity'
+
+/** Builds a supplier-activity page URL preserving filters, for a given page number. */
+export function buildSupplierActivityHref(
+  filters: SupplierActivityFilterQuery,
+  page: number,
+): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) params.set(key, value)
+  }
+  if (page > 1) params.set('page', String(page))
+  const qs = params.toString()
+  return qs ? `${SUPPLIER_ACTIVITY_PATH}?${qs}` : SUPPLIER_ACTIVITY_PATH
+}


### PR DESCRIPTION
Splits app/dashboard/supplier-activity/page.tsx's combined responsibilities into focused, testable pieces so the page component is limited to server-side orchestration and composition:

- lib/suppliers/supplier-activity-authorization.ts: session/role check
- lib/suppliers/supplier-activity-params.ts: search-param parsing and commercial-status validation
- lib/suppliers/supplier-activity-url.ts: pagination query-string/URL generation
- lib/suppliers/supplier-activity-labels.ts: translation-label mapping helpers, replacing large inline label objects in the page
- components/supplier-activity/{activity,product-performance, customer-activity}-section.tsx and pagination-controls.tsx: repeated section composition extracted into small components

Behavior (auth redirects, filters, pagination, localized labels, error rendering, activity tables) is unchanged. Adds focused unit tests for each extracted utility and the new pagination component.

Closes #171

