### PR TITLE
Enhance admin functionality by adding 'set_user_type' to AUDIT_ACTIO

### DIFF
--- a/__tests__/admin/admin-audit.test.ts
+++ b/__tests__/admin/admin-audit.test.ts
@@ -58,7 +58,12 @@ const sampleRow = {
 
 describe('AUDIT_ACTIONS', () => {
   test('covers the actions written by the mutation RPCs', () => {
-    expect([...AUDIT_ACTIONS]).toEqual(['verify', 'unverify', 'update_profile'])
+    expect([...AUDIT_ACTIONS]).toEqual([
+      'verify',
+      'unverify',
+      'update_profile',
+      'set_user_type',
+    ])
   })
 })
 

--- a/__tests__/admin/set-user-type-route.test.ts
+++ b/__tests__/admin/set-user-type-route.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+type RpcCall = { fn: string; args: Record<string, unknown> }
+
+const state = {
+  adminOk: true,
+  rpcResult: { data: 'audit-role-1', error: null as { code?: string } | null },
+  rpcCalls: [] as RpcCall[],
+}
+
+mock.module('@/lib/ramp-api', () => ({
+  requireAdmin: async () =>
+    state.adminOk
+      ? { ok: true, userId: 'admin-1', email: 'admin@mercato.xyz' }
+      : {
+          ok: false,
+          response: Response.json({ error: 'Forbidden' }, { status: 403 }),
+        },
+}))
+
+mock.module('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    rpc: async (fn: string, args: Record<string, unknown>) => {
+      state.rpcCalls.push({ fn, args })
+      return state.rpcResult
+    },
+  }),
+}))
+
+const { POST } = await import('@/app/api/admin/users/[id]/role/route')
+
+function post(body: unknown, id = 'user-1'): Promise<Response> {
+  return POST(
+    new Request(`http://localhost/api/admin/users/${id}/role`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  )
+}
+
+beforeEach(() => {
+  state.adminOk = true
+  state.rpcResult = { data: 'audit-role-1', error: null }
+  state.rpcCalls = []
+})
+
+afterEach(() => {
+  mock.restore()
+})
+
+test('passes the guard response through for non-admins', async () => {
+  state.adminOk = false
+  const res = await post({ userType: 'admin' })
+  expect(res.status).toBe(403)
+  expect(state.rpcCalls).toHaveLength(0)
+})
+
+test('invokes admin_set_user_type with the exact arguments', async () => {
+  const res = await post({ userType: 'admin', reason: 'Ops onboarding' })
+  expect(res.status).toBe(200)
+  expect(await res.json()).toEqual({ ok: true, auditEventId: 'audit-role-1' })
+  expect(state.rpcCalls).toEqual([
+    {
+      fn: 'admin_set_user_type',
+      args: {
+        p_profile_id: 'user-1',
+        p_user_type: 'admin',
+        p_reason: 'Ops onboarding',
+      },
+    },
+  ])
+})
+
+test('rejects unknown roles without calling the RPC', async () => {
+  const res = await post({ userType: 'superadmin' })
+  expect(res.status).toBe(400)
+  expect(state.rpcCalls).toHaveLength(0)
+})
+
+test('maps RPC forbidden and not-found errors to HTTP statuses', async () => {
+  state.rpcResult = { data: null, error: { code: '42501' } }
+  expect((await post({ userType: 'pyme' })).status).toBe(403)
+
+  state.rpcResult = { data: null, error: { code: 'P0002' } }
+  expect((await post({ userType: 'pyme' })).status).toBe(404)
+})

--- a/__tests__/deals/repayment-escrow-commands.test.ts
+++ b/__tests__/deals/repayment-escrow-commands.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from 'bun:test'
+import { createRepaymentEscrowCommands } from '@/lib/deals/repayment-escrow-commands'
+import { DEFAULT_REPAYMENT_RETRY_POLICY } from '@/lib/deals/repayment-retry'
+import type {
+  DealRepository,
+  EscrowBuilder,
+  IndexerPort,
+  RepaymentEscrowConfig,
+  SendTxResult,
+  TxTransport,
+} from '@/lib/deals/repayment-escrow-types'
+
+const config: RepaymentEscrowConfig = {
+  platformAddress: 'GPLATFORM',
+  trustline: { address: 'CUSDC', symbol: 'USDC' },
+  roles: () => ({
+    approver: 'GPLATFORM',
+    serviceProvider: 'GPLATFORM',
+    platformAddress: 'GPLATFORM',
+    releaseSigner: 'GPLATFORM',
+    disputeResolver: 'GRESOLVER',
+  }),
+}
+
+function mockDeals(overrides: Partial<DealRepository> = {}): DealRepository & {
+  patches: Record<string, unknown>[]
+} {
+  const patches: Record<string, unknown>[] = []
+  return {
+    patches,
+    getRepaymentDueAt: async () => '2026-02-01T00:00:00.000Z',
+    getRepaymentTotal: async () => 100,
+    updateDeal: async (_id, patch) => {
+      patches.push(patch)
+    },
+    resolveInvestorWallet: async () => 'GINVESTOR',
+    ...overrides,
+  }
+}
+
+function mockBuilder(overrides: Partial<EscrowBuilder> = {}): EscrowBuilder {
+  const ok = async () => ({ status: 'SUCCESS', unsignedTransaction: 'XDR' })
+  return {
+    initialize: ok,
+    fund: ok,
+    approveMilestone: ok,
+    releaseFunds: ok,
+    updateEscrow: ok,
+    startDispute: ok,
+    resolveDispute: ok,
+    ...overrides,
+  }
+}
+
+describe('repayment escrow commands', () => {
+  test('deploy uses the send result contract id and does not overwrite due date', async () => {
+    const deals = mockDeals()
+    const waits: number[] = []
+    const signed: string[] = []
+    const transport: TxTransport = {
+      async signAndSend(unsigned, address, provider) {
+        signed.push(`${provider}:${address}:${unsigned}`)
+        return {
+          status: 'SUCCESS',
+          contractId: 'CDEPLOY',
+        } satisfies SendTxResult
+      },
+    }
+    const indexer: IndexerPort = {
+      getByContractId: async () => null,
+      getBySigner: async () => [],
+      getBalance: async () => null,
+    }
+    const commands = createRepaymentEscrowCommands({
+      builder: mockBuilder(),
+      transport,
+      indexer,
+      deals,
+      config,
+      wait: async (ms) => {
+        waits.push(ms)
+      },
+    })
+
+    const result = await commands.deployRepaymentEscrow({
+      dealId: 'deal-1',
+      adminAddress: 'GADMIN',
+      principal: 10_000,
+      aprPercent: 5,
+      termDays: 30,
+      productName: 'Coffee',
+      provider: 'stellar-wallets-kit',
+    })
+
+    expect(result.contractId).toBe('CDEPLOY')
+    expect(signed).toEqual(['stellar-wallets-kit:GADMIN:XDR'])
+    expect(waits).toEqual([])
+    expect(deals.patches[0]).toMatchObject({
+      escrow_contract_address: 'CDEPLOY',
+      repayment_status: 'escrow_initialized',
+    })
+    expect(deals.patches[0]).not.toHaveProperty('repayment_due_at')
+  })
+
+  test('pollar deploy looks up the contract id with the configured delay', async () => {
+    const deals = mockDeals()
+    const waits: number[] = []
+    let lookups = 0
+    const indexer: IndexerPort = {
+      getByContractId: async () => null,
+      getBySigner: async () => {
+        lookups += 1
+        if (lookups < 2) return []
+        return [
+          { engagementId: 'deal-1:repayment', contractId: 'CPOLLAR' },
+        ] as never
+      },
+      getBalance: async () => null,
+    }
+    const commands = createRepaymentEscrowCommands({
+      builder: mockBuilder(),
+      transport: {
+        signAndSend: async () => undefined,
+      },
+      indexer,
+      deals,
+      config,
+      wait: async (ms) => {
+        waits.push(ms)
+      },
+    })
+
+    const result = await commands.deployRepaymentEscrow({
+      dealId: 'deal-1',
+      adminAddress: 'GADMIN',
+      principal: 10_000,
+      aprPercent: 5,
+      termDays: 30,
+      productName: 'Coffee',
+      provider: 'pollar',
+    })
+
+    expect(result.contractId).toBe('CPOLLAR')
+    expect(lookups).toBe(2)
+    expect(waits).toEqual([DEFAULT_REPAYMENT_RETRY_POLICY.pollarContractLookup.delayMs])
+  })
+
+  test('fund signs then waits the configured indexer lag before reconcile', async () => {
+    const waits: number[] = []
+    const deals = mockDeals()
+    const indexer: IndexerPort = {
+      getByContractId: async () =>
+        ({
+          milestones: [{ description: 'M1', amount: 100, flags: { released: false } }],
+          balance: 100,
+        }) as never,
+      getBySigner: async () => [],
+      getBalance: async () => 100,
+    }
+    let signed = 0
+    const commands = createRepaymentEscrowCommands({
+      builder: mockBuilder(),
+      transport: {
+        signAndSend: async () => {
+          signed += 1
+          return { status: 'SUCCESS' }
+        },
+      },
+      indexer,
+      deals,
+      config,
+      wait: async (ms) => {
+        waits.push(ms)
+      },
+    })
+
+    await commands.fundRepaymentEscrow({
+      dealId: 'deal-1',
+      contractId: 'C1',
+      pymeAddress: 'GPYME',
+      amount: 50,
+      provider: null,
+    })
+
+    expect(signed).toBe(1)
+    expect(waits).toEqual([DEFAULT_REPAYMENT_RETRY_POLICY.afterCommandMs.fund])
+    expect(deals.patches[0]).toMatchObject({ repayment_status: 'ready_to_release' })
+  })
+
+  test('approve uses the shorter post-command delay; release uses the fund delay', async () => {
+    const waits: number[] = []
+    const indexer: IndexerPort = {
+      getByContractId: async () =>
+        ({
+          milestones: [{ description: 'M1', amount: 100, flags: { released: false } }],
+          balance: 0,
+        }) as never,
+      getBySigner: async () => [],
+      getBalance: async () => 0,
+    }
+    const commands = createRepaymentEscrowCommands({
+      builder: mockBuilder(),
+      transport: { signAndSend: async () => ({ status: 'SUCCESS' }) },
+      indexer,
+      deals: mockDeals(),
+      config,
+      wait: async (ms) => {
+        waits.push(ms)
+      },
+    })
+
+    const params = {
+      dealId: 'deal-1',
+      contractId: 'C1',
+      releaseSigner: 'GSIGN',
+      milestoneIndex: 0,
+      provider: null,
+    }
+    await commands.approveRepaymentMilestone(params)
+    await commands.releaseRepaymentMilestone(params)
+
+    expect(waits).toEqual([
+      DEFAULT_REPAYMENT_RETRY_POLICY.afterCommandMs.approve,
+      DEFAULT_REPAYMENT_RETRY_POLICY.afterCommandMs.release,
+    ])
+  })
+
+  test('keeps signing on the provided wallet address', async () => {
+    const signers: string[] = []
+    const indexer: IndexerPort = {
+      getByContractId: async () =>
+        ({
+          milestones: [{ description: 'M1', amount: 100, flags: { released: false } }],
+          balance: 0,
+        }) as never,
+      getBySigner: async () => [],
+      getBalance: async () => 0,
+    }
+    const commands = createRepaymentEscrowCommands({
+      builder: mockBuilder(),
+      transport: {
+        signAndSend: async (_unsigned, address) => {
+          signers.push(address)
+          return { status: 'SUCCESS' }
+        },
+      },
+      indexer,
+      deals: mockDeals(),
+      config,
+      wait: async () => {},
+    })
+
+    await commands.startRepaymentDispute({
+      dealId: 'deal-1',
+      contractId: 'C1',
+      signer: 'GDISPUTE',
+      milestoneIndex: 0,
+      provider: 'stellar-wallets-kit',
+    })
+    await commands.resolveRepaymentDispute({
+      dealId: 'deal-1',
+      contractId: 'C1',
+      disputeResolver: 'GRESOLVER',
+      milestoneIndex: 0,
+      distributions: [{ address: 'GINVESTOR', amount: 100 }],
+      provider: 'stellar-wallets-kit',
+    })
+
+    expect(signers).toEqual(['GDISPUTE', 'GRESOLVER'])
+  })
+})
+
+describe('DEFAULT_REPAYMENT_RETRY_POLICY', () => {
+  test('preserves the previous hardcoded delays', () => {
+    expect(DEFAULT_REPAYMENT_RETRY_POLICY).toEqual({
+      indexerEmptyMilestones: { extraAttempts: 2, delayMs: 2000 },
+      pollarContractLookup: { attempts: 5, delayMs: 3000 },
+      afterCommandMs: {
+        fund: 1500,
+        approve: 1000,
+        release: 1500,
+        addMilestone: 1500,
+        dispute: 1500,
+        resolveDispute: 1500,
+        approveAndRelease: 1500,
+      },
+    })
+  })
+})

--- a/__tests__/deals/repayment-escrow-payloads.test.ts
+++ b/__tests__/deals/repayment-escrow-payloads.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  buildApprovePayload,
+  buildFundPayload,
+  buildReleasePayload,
+  buildResolveDisputePayload,
+  buildStartDisputePayload,
+  cleanDistributions,
+  contractIdFromSendResult,
+  planAddMilestone,
+  planRepaymentDeploy,
+  repaymentDueAtIso,
+  requireUnsigned,
+} from '@/lib/deals/repayment-escrow-payloads'
+import type { RepaymentEscrowRoles } from '@/lib/deals/repayment-escrow-types'
+
+const roles: RepaymentEscrowRoles = {
+  approver: 'GPLATFORM',
+  serviceProvider: 'GPLATFORM',
+  platformAddress: 'GPLATFORM',
+  releaseSigner: 'GPLATFORM',
+  disputeResolver: 'GRESOLVER',
+}
+
+const trustline = { address: 'CUSDC', symbol: 'USDC' }
+
+describe('repayment escrow payloads', () => {
+  test('planRepaymentDeploy builds the initialize payload and first milestone', () => {
+    const planned = planRepaymentDeploy({
+      params: {
+        dealId: 'deal-1',
+        adminAddress: 'GADMIN',
+        principal: 10_000,
+        aprPercent: 5,
+        termDays: 30,
+        productName: 'Coffee',
+        firstMilestonePercent: 50,
+        provider: 'stellar-wallets-kit',
+      },
+      investorAddress: 'GINVESTOR',
+      roles,
+      trustline,
+    })
+
+    expect(planned.engagementId).toBe('deal-1:repayment')
+    expect(planned.totalGrossed).toBe(10_638.3)
+    expect(planned.payload.signer).toBe('GADMIN')
+    expect(planned.payload.roles).toEqual(roles)
+    expect(planned.payload.trustline).toEqual(trustline)
+    expect(planned.payload.milestones).toEqual([
+      {
+        description: 'Repayment milestone 1 (50%)',
+        amount: 5_319.15,
+        receiver: 'GINVESTOR',
+      },
+    ])
+    expect(planned.initialMilestones).toEqual([
+      {
+        index: 0,
+        description: 'Repayment milestone 1 (50%)',
+        amount: 5_319.15,
+        released: false,
+      },
+    ])
+  })
+
+  test('planRepaymentDeploy rejects a non-positive first milestone', () => {
+    expect(() =>
+      planRepaymentDeploy({
+        params: {
+          dealId: 'deal-1',
+          adminAddress: 'GADMIN',
+          principal: 0,
+          aprPercent: 5,
+          termDays: 30,
+          productName: 'Coffee',
+          provider: null,
+        },
+        investorAddress: 'GINVESTOR',
+        roles,
+        trustline,
+      }),
+    ).toThrow('First milestone amount must be positive')
+  })
+
+  test('buildFundPayload rounds and rejects non-positive amounts', () => {
+    expect(
+      buildFundPayload({
+        dealId: 'd',
+        contractId: 'C1',
+        pymeAddress: 'GPYME',
+        amount: 10.239,
+        provider: null,
+      }),
+    ).toEqual({ contractId: 'C1', signer: 'GPYME', amount: 10.24 })
+    expect(() =>
+      buildFundPayload({
+        dealId: 'd',
+        contractId: 'C1',
+        pymeAddress: 'GPYME',
+        amount: 0,
+        provider: null,
+      }),
+    ).toThrow('Fund amount must be positive')
+  })
+
+  test('approve, release, and dispute payloads stringify the index', () => {
+    const release = {
+      dealId: 'd',
+      contractId: 'C1',
+      releaseSigner: 'GSIGN',
+      milestoneIndex: 2,
+      provider: null,
+    }
+    expect(buildApprovePayload(release)).toEqual({
+      contractId: 'C1',
+      milestoneIndex: '2',
+      approver: 'GSIGN',
+    })
+    expect(buildReleasePayload(release)).toEqual({
+      contractId: 'C1',
+      releaseSigner: 'GSIGN',
+      milestoneIndex: '2',
+    })
+    expect(
+      buildStartDisputePayload({
+        dealId: 'd',
+        contractId: 'C1',
+        signer: 'GSIGN',
+        milestoneIndex: 1,
+        provider: null,
+      }),
+    ).toEqual({
+      contractId: 'C1',
+      signer: 'GSIGN',
+      milestoneIndex: '1',
+    })
+  })
+
+  test('cleanDistributions drops empty rows and requires a positive remainder', () => {
+    expect(
+      cleanDistributions([
+        { address: '  GINV  ', amount: 10.239 },
+        { address: '', amount: 5 },
+        { address: 'GPYME', amount: 0 },
+      ]),
+    ).toEqual([{ address: 'GINV', amount: 10.24 }])
+    expect(() =>
+      cleanDistributions([{ address: 'GINV', amount: 0 }]),
+    ).toThrow('At least one positive distribution is required')
+  })
+
+  test('buildResolveDisputePayload uses cleaned distributions', () => {
+    expect(
+      buildResolveDisputePayload({
+        dealId: 'd',
+        contractId: 'C1',
+        disputeResolver: 'GRES',
+        milestoneIndex: 0,
+        distributions: [{ address: 'GINV', amount: 50 }],
+        provider: null,
+      }),
+    ).toMatchObject({
+      contractId: 'C1',
+      disputeResolver: 'GRES',
+      milestoneIndex: '0',
+      distributions: [{ address: 'GINV', amount: 50 }],
+    })
+  })
+
+  test('planAddMilestone defaults to remaining and rejects an overshoot', () => {
+    const escrow = {
+      engagementId: 'deal-1:repayment',
+      title: 'T',
+      description: 'D',
+      platformFee: 1,
+      trustline,
+      isActive: true,
+      milestones: [
+        {
+          description: 'M1',
+          amount: 50,
+          receiver: 'GINVESTOR',
+          flags: { released: true },
+        },
+      ],
+    }
+    const planned = planAddMilestone({
+      params: {
+        dealId: 'deal-1',
+        contractId: 'C1',
+        adminAddress: 'GADMIN',
+        provider: null,
+      },
+      escrow: escrow as never,
+      totalGrossed: 100,
+      investorAddress: 'GINVESTOR',
+      roles,
+    })
+    expect(planned.amount).toBe(50)
+    expect(planned.updatePayload.escrow.milestones).toHaveLength(2)
+
+    expect(() =>
+      planAddMilestone({
+        params: {
+          dealId: 'deal-1',
+          contractId: 'C1',
+          adminAddress: 'GADMIN',
+          amount: 80,
+          provider: null,
+        },
+        escrow: escrow as never,
+        totalGrossed: 100,
+        investorAddress: 'GINVESTOR',
+        roles,
+      }),
+    ).toThrow('Milestone amount exceeds remaining (50 USDC)')
+  })
+
+  test('requireUnsigned and contractIdFromSendResult', () => {
+    expect(
+      requireUnsigned(
+        { status: 'SUCCESS', unsignedTransaction: 'XDR' },
+        'fail',
+      ),
+    ).toBe('XDR')
+    expect(() => requireUnsigned({ status: 'ERROR' }, 'boom')).toThrow('boom')
+    expect(
+      contractIdFromSendResult({
+        status: 'SUCCESS',
+        escrow: { contractId: 'CNESTED' },
+      }),
+    ).toBe('CNESTED')
+    expect(
+      contractIdFromSendResult({ status: 'SUCCESS', contractId: 'CTOP' }),
+    ).toBe('CTOP')
+    expect(contractIdFromSendResult(undefined)).toBeUndefined()
+  })
+
+  test('repaymentDueAtIso uses term days from now', () => {
+    expect(repaymentDueAtIso(30, new Date('2026-01-01T00:00:00.000Z'))).toBe(
+      '2026-01-31T00:00:00.000Z',
+    )
+    expect(repaymentDueAtIso(0, new Date('2026-01-01T00:00:00.000Z'))).toBe(
+      '2026-01-02T00:00:00.000Z',
+    )
+  })
+})

--- a/__tests__/deals/repayment-escrow-reconcile.test.ts
+++ b/__tests__/deals/repayment-escrow-reconcile.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test'
+import { syncDealFromIndexer } from '@/lib/deals/repayment-escrow-reconcile'
+import { DEFAULT_REPAYMENT_RETRY_POLICY } from '@/lib/deals/repayment-retry'
+import type {
+  DealRepository,
+  IndexerPort,
+} from '@/lib/deals/repayment-escrow-types'
+
+function mockDeals(overrides: Partial<DealRepository> = {}): DealRepository & {
+  patches: Record<string, unknown>[]
+} {
+  const patches: Record<string, unknown>[] = []
+  return {
+    patches,
+    getRepaymentDueAt: async () => null,
+    getRepaymentTotal: async () => 100,
+    updateDeal: async (_id, patch) => {
+      patches.push(patch)
+    },
+    resolveInvestorWallet: async () => 'GINVESTOR',
+    ...overrides,
+  }
+}
+
+describe('syncDealFromIndexer', () => {
+  test('retries empty milestones on the configured delay then persists', async () => {
+    const waits: number[] = []
+    let calls = 0
+    const indexer: IndexerPort = {
+      getByContractId: async () => {
+        calls += 1
+        if (calls < 3) return { milestones: [], balance: 0 } as never
+        return {
+          milestones: [{ description: 'M1', amount: 100, flags: { released: false } }],
+          balance: 40,
+        } as never
+      },
+      getBySigner: async () => [],
+      getBalance: async () => 40,
+    }
+    const deals = mockDeals()
+
+    const result = await syncDealFromIndexer(
+      indexer,
+      deals,
+      async (ms) => {
+        waits.push(ms)
+      },
+      DEFAULT_REPAYMENT_RETRY_POLICY,
+      'deal-1',
+      'C1',
+    )
+
+    expect(calls).toBe(3)
+    expect(waits).toEqual([2000, 2000])
+    expect(result.status).toBe('funding')
+    expect(result.balance).toBe(40)
+    expect(deals.patches[0]).toMatchObject({
+      repayment_status: 'funding',
+      escrow_status: 'active',
+    })
+  })
+
+  test('skips retry when asked and keeps indexer balance fallback', async () => {
+    const waits: number[] = []
+    const indexer: IndexerPort = {
+      getByContractId: async () =>
+        ({ milestones: [], balance: 12 } as never),
+      getBySigner: async () => [],
+      getBalance: async () => {
+        throw new Error('balance endpoint down')
+      },
+    }
+    const deals = mockDeals()
+
+    const result = await syncDealFromIndexer(
+      indexer,
+      deals,
+      async (ms) => {
+        waits.push(ms)
+      },
+      DEFAULT_REPAYMENT_RETRY_POLICY,
+      'deal-1',
+      'C1',
+      undefined,
+      { retryOnEmptyMilestones: false },
+    )
+
+    expect(waits).toEqual([])
+    expect(result.status).toBe('escrow_initialized')
+    expect(result.balance).toBe(12)
+  })
+
+  test('marks the deal completed when every milestone is released', async () => {
+    const indexer: IndexerPort = {
+      getByContractId: async () =>
+        ({
+          milestones: [
+            { description: 'M1', amount: 100, flags: { released: true } },
+          ],
+          balance: 0,
+        }) as never,
+      getBySigner: async () => [],
+      getBalance: async () => 0,
+    }
+    const deals = mockDeals({ getRepaymentTotal: async () => 100 })
+
+    const result = await syncDealFromIndexer(
+      indexer,
+      deals,
+      async () => {},
+      DEFAULT_REPAYMENT_RETRY_POLICY,
+      'deal-1',
+      'C1',
+    )
+
+    expect(result.status).toBe('released')
+    expect(deals.patches[0]).toMatchObject({
+      repayment_status: 'released',
+      escrow_status: 'completed',
+      status: 'completed',
+    })
+    expect(typeof deals.patches[0].completed_at).toBe('string')
+  })
+})

--- a/__tests__/profile/onboarding.test.ts
+++ b/__tests__/profile/onboarding.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { isOnboardingUserType, resolveSignupUserType } from '@/lib/profile/onboarding'
+
+const MIGRATION = resolve(
+  import.meta.dir,
+  '../../supabase/migrations/20260827000100_reject_admin_signup_metadata.sql',
+)
+
+describe('resolveSignupUserType', () => {
+  test('keeps permitted onboarding roles', () => {
+    expect(resolveSignupUserType('pyme')).toBe('pyme')
+    expect(resolveSignupUserType('investor')).toBe('investor')
+    expect(resolveSignupUserType('supplier')).toBe('supplier')
+    expect(isOnboardingUserType('pyme')).toBe(true)
+  })
+
+  test('trims whitespace on permitted roles', () => {
+    expect(resolveSignupUserType('  investor  ')).toBe('investor')
+  })
+
+  test('cannot elevate via attacker-controlled signup metadata', () => {
+    expect(resolveSignupUserType('admin')).toBeNull()
+    expect(resolveSignupUserType('ADMIN')).toBeNull()
+    expect(resolveSignupUserType(' admin ')).toBeNull()
+    expect(isOnboardingUserType('admin')).toBe(false)
+  })
+
+  test('unknown or empty metadata stays unassigned', () => {
+    expect(resolveSignupUserType(null)).toBeNull()
+    expect(resolveSignupUserType(undefined)).toBeNull()
+    expect(resolveSignupUserType('')).toBeNull()
+    expect(resolveSignupUserType('moderator')).toBeNull()
+    expect(resolveSignupUserType({ user_type: 'admin' })).toBeNull()
+  })
+})
+
+describe('handle_new_user migration', () => {
+  const sql = readFileSync(MIGRATION, 'utf8')
+
+  test('signup allowlist excludes admin', () => {
+    expect(sql).toContain("meta_type in ('pyme', 'investor', 'supplier')")
+    expect(sql).not.toContain("meta_type in ('pyme', 'investor', 'supplier', 'admin')")
+  })
+
+  test('insert trigger strips admin unless service_role', () => {
+    expect(sql).toContain('enforce_profile_insert_privileged_fields')
+    expect(sql).toContain("if new.user_type = 'admin' then")
+    expect(sql).toContain('new.user_type := null')
+  })
+
+  test('authorised provisioning stays on admin_set_user_type', () => {
+    expect(sql).toContain('create or replace function public.admin_set_user_type')
+    expect(sql).toContain('v_admin uuid := assert_admin()')
+    expect(sql).toContain("'set_user_type'")
+  })
+})

--- a/app/api/admin/users/[id]/role/route.ts
+++ b/app/api/admin/users/[id]/role/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import { requireAdmin } from '@/lib/ramp-api'
+import { createClient } from '@/lib/supabase/server'
+
+export const dynamic = 'force-dynamic'
+
+const USER_TYPES = new Set(['pyme', 'investor', 'supplier', 'admin'])
+
+type RoleBody = {
+  userType?: unknown
+  reason?: unknown
+}
+
+/**
+ * POST /api/admin/users/[id]/role — assign a profile role.
+ * Signup metadata cannot grant admin; this RPC re-checks the caller is admin
+ * and writes the audit event in the same transaction.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await params
+  if (!id) {
+    return NextResponse.json({ error: 'Missing user id' }, { status: 400 })
+  }
+
+  let body: RoleBody
+  try {
+    body = (await request.json()) as RoleBody
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { userType, reason } = body
+  if (
+    typeof userType !== 'string' ||
+    !USER_TYPES.has(userType) ||
+    (reason != null && typeof reason !== 'string')
+  ) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase.rpc('admin_set_user_type', {
+    p_profile_id: id,
+    p_user_type: userType,
+    p_reason: reason ?? null,
+  })
+
+  if (error) {
+    if (error.code === '42501') {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    if (error.code === 'P0002') {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    console.error('[admin:users:role]', error)
+    return NextResponse.json({ error: 'Role update failed' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, auditEventId: data })
+}

--- a/app/dashboard/admin/admin-escrows-provider.tsx
+++ b/app/dashboard/admin/admin-escrows-provider.tsx
@@ -14,6 +14,7 @@ import type {
   ReleaseFallbackItem,
 } from '@/lib/admin/types'
 import { useI18n } from '@/lib/i18n/provider'
+import { useRepaymentCommandRefresh } from '@/hooks/use-repayment-command-refresh'
 
 interface AdminEscrowsProviderProps {
   items: PendingApprovalItem[]
@@ -31,6 +32,7 @@ export function AdminEscrowsProvider({
   releaseFallbackItems,
 }: AdminEscrowsProviderProps) {
   const { t } = useI18n()
+  const { epoch, refreshAfterCommand } = useRepaymentCommandRefresh()
   const { getEscrowByContractIds } = useGetEscrowFromIndexerByContractIds()
   const getEscrowRef = useRef(getEscrowByContractIds)
   getEscrowRef.current = getEscrowByContractIds
@@ -78,7 +80,7 @@ export function AdminEscrowsProvider({
     return () => {
       cancelled = true
     }
-  }, [contractIdsKey])
+  }, [contractIdsKey, epoch])
 
   // Release-ready items already appear in the manage queue — only surface a
   // compact release strip when Approvals has no manage items but Releases does.
@@ -97,7 +99,10 @@ export function AdminEscrowsProvider({
             <CardDescription>{t('adminCreateEscrow.cardDescription')}</CardDescription>
           </CardHeader>
           <CardContent>
-            <CreateRepaymentEscrows items={createEscrowItems} />
+            <CreateRepaymentEscrows
+              items={createEscrowItems}
+              onAfterCommand={refreshAfterCommand}
+            />
           </CardContent>
         </Card>
       ) : null}
@@ -111,7 +116,11 @@ export function AdminEscrowsProvider({
           <CardDescription>{t('adminEscrows.pendingCardDescription')}</CardDescription>
         </CardHeader>
         <CardContent>
-          <PendingApprovals items={items} escrowsByContractId={escrowsByContractId} />
+          <PendingApprovals
+            items={items}
+            escrowsByContractId={escrowsByContractId}
+            onAfterCommand={refreshAfterCommand}
+          />
         </CardContent>
       </Card>
 
@@ -128,6 +137,7 @@ export function AdminEscrowsProvider({
             <ReleaseFundsFallback
               items={releaseFallbackItems}
               escrowsByContractId={escrowsByContractId}
+              onAfterCommand={refreshAfterCommand}
             />
           </CardContent>
         </Card>

--- a/app/dashboard/admin/admin-resolve-dispute-dialog.tsx
+++ b/app/dashboard/admin/admin-resolve-dispute-dialog.tsx
@@ -41,12 +41,14 @@ interface AdminResolveDisputeDialogProps {
   target: ResolveDisputeTarget | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onAfterCommand?: () => void | Promise<void>
 }
 
 export function AdminResolveDisputeDialog({
   target,
   open,
   onOpenChange,
+  onAfterCommand,
 }: AdminResolveDisputeDialogProps) {
   const { t } = useI18n()
   const { walletInfo, isConnected, handleConnect, provider } = useWallet()
@@ -143,7 +145,7 @@ export function AdminResolveDisputeDialog({
         t('adminDispute.resolveSuccess', { title: target.milestoneTitle }),
       )
       onOpenChange(false)
-      window.location.reload()
+      await onAfterCommand?.()
     } catch (err) {
       console.error(err)
       toast.error(

--- a/app/dashboard/admin/create-repayment-escrows.tsx
+++ b/app/dashboard/admin/create-repayment-escrows.tsx
@@ -10,6 +10,7 @@ import { Badge } from '@/components/ui/badge'
 import { Wallet, ExternalLink, Building2, Rocket } from 'lucide-react'
 import { useWallet } from '@/hooks/use-wallet'
 import { useRepaymentEscrow } from '@/hooks/use-repayment-escrow'
+import { useRepaymentCommandRefresh } from '@/hooks/use-repayment-command-refresh'
 import { useI18n } from '@/lib/i18n/provider'
 import { formatCurrency } from '@/lib/format'
 import {
@@ -21,13 +22,19 @@ import { MERCATO_PLATFORM_ADDRESS } from '@/lib/trustless/config'
 
 interface CreateRepaymentEscrowsProps {
   items: CreateEscrowItem[]
+  onAfterCommand?: () => void | Promise<void>
 }
 
-export function CreateRepaymentEscrows({ items }: CreateRepaymentEscrowsProps) {
+export function CreateRepaymentEscrows({
+  items,
+  onAfterCommand,
+}: CreateRepaymentEscrowsProps) {
   const { t, locale } = useI18n()
   const numLocale = locale === 'es' ? 'es-MX' : 'en-US'
   const { walletInfo, isConnected, handleConnect, provider } = useWallet()
   const { isWorking, deployRepaymentEscrow } = useRepaymentEscrow()
+  const { refreshAfterCommand } = useRepaymentCommandRefresh()
+  const completeCommand = onAfterCommand ?? refreshAfterCommand
   const [deployingId, setDeployingId] = useState<string | null>(null)
   const [percents, setPercents] = useState<Record<string, string>>({})
 
@@ -70,7 +77,7 @@ export function CreateRepaymentEscrows({ items }: CreateRepaymentEscrowsProps) {
         provider,
       })
       toast.success(t('adminCreateEscrow.deploySuccess'))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       console.error(err)
       toast.error(

--- a/app/dashboard/admin/pending-approvals.tsx
+++ b/app/dashboard/admin/pending-approvals.tsx
@@ -42,18 +42,26 @@ import {
   MERCATO_PLATFORM_ADDRESS,
   MERCATO_DISPUTE_RESOLVER_ADDRESS,
 } from '@/lib/trustless/config'
+import {
+  useRepaymentCommandRefresh,
+  type AfterRepaymentCommand,
+} from '@/hooks/use-repayment-command-refresh'
 
 interface PendingApprovalsProps {
   items: PendingApprovalItem[]
   /** When provided (from AdminEscrowsProvider), skip internal fetch to avoid duplicate API calls */
   escrowsByContractId?: Map<string, GetEscrowsFromIndexerResponse>
+  onAfterCommand?: AfterRepaymentCommand
 }
 
 export function PendingApprovals({
   items,
   escrowsByContractId: escrowsFromParent,
+  onAfterCommand,
 }: PendingApprovalsProps) {
   const { t, locale } = useI18n()
+  const { refreshAfterCommand } = useRepaymentCommandRefresh()
+  const completeCommand = onAfterCommand ?? refreshAfterCommand
   const numLocale = locale === 'es' ? 'es-MX' : 'en-US'
   const [approvingId, setApprovingId] = useState<string | null>(null)
   const [releasingId, setReleasingId] = useState<string | null>(null)
@@ -134,7 +142,7 @@ export function PendingApprovals({
         provider,
       })
       toast.success(t('adminPending.approveSuccess', { title: item.milestoneTitle }))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       const message = err instanceof Error ? err.message : t('adminPending.approveFail')
       console.error('Approve milestone error:', err)
@@ -163,7 +171,7 @@ export function PendingApprovals({
         provider,
       })
       toast.success(t('adminPending.releaseSuccess', { title: item.milestoneTitle }))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       const message = err instanceof Error ? err.message : t('adminPending.releaseFail')
       console.error('Release funds error:', err)
@@ -179,7 +187,7 @@ export function PendingApprovals({
     try {
       await syncDealFromIndexer(item.dealId, item.escrowContractAddress)
       toast.success(t('adminPending.resyncSuccess'))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       console.error(err)
       toast.error(
@@ -225,7 +233,7 @@ export function PendingApprovals({
       toast.success(
         t('adminDispute.startSuccess', { title: item.milestoneTitle }),
       )
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       console.error(err)
       toast.error(
@@ -256,7 +264,7 @@ export function PendingApprovals({
         provider,
       })
       toast.success(t('dealDetail.repaymentMilestoneAdded'))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       console.error(err)
       toast.error(
@@ -286,6 +294,7 @@ export function PendingApprovals({
         onOpenChange={(next) => {
           if (!next) setDisputeTarget(null)
         }}
+        onAfterCommand={completeCommand}
       />
       {items.map((item) => {
         const escrow = escrowsByContractId.get(item.escrowContractAddress)

--- a/app/dashboard/admin/release-funds-fallback.tsx
+++ b/app/dashboard/admin/release-funds-fallback.tsx
@@ -6,6 +6,7 @@ import { useGetEscrowFromIndexerByContractIds } from '@trustless-work/escrow/hoo
 import type { GetEscrowsFromIndexerResponse } from '@trustless-work/escrow'
 import { useWallet } from '@/hooks/use-wallet'
 import { useRepaymentEscrow } from '@/hooks/use-repayment-escrow'
+import { useRepaymentCommandRefresh } from '@/hooks/use-repayment-command-refresh'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -29,13 +30,17 @@ interface ReleaseFundsFallbackProps {
   items: ReleaseFallbackItem[]
   /** When provided (from AdminEscrowsProvider), skip internal fetch to avoid duplicate API calls */
   escrowsByContractId?: Map<string, GetEscrowsFromIndexerResponse>
+  onAfterCommand?: () => void | Promise<void>
 }
 
 export function ReleaseFundsFallback({
   items,
   escrowsByContractId: escrowsFromParent,
+  onAfterCommand,
 }: ReleaseFundsFallbackProps) {
   const { t, locale } = useI18n()
+  const { epoch, refreshAfterCommand } = useRepaymentCommandRefresh()
+  const completeCommand = onAfterCommand ?? refreshAfterCommand
   const numLocale = locale === 'es' ? 'es-MX' : 'en-US'
   const [approvingId, setApprovingId] = useState<string | null>(null)
   const [releasingId, setReleasingId] = useState<string | null>(null)
@@ -90,7 +95,7 @@ export function ReleaseFundsFallback({
     return () => {
       cancelled = true
     }
-  }, [contractIdsKey, escrowsFromParent])
+  }, [contractIdsKey, escrowsFromParent, epoch])
 
   const handleApproveOnly = async (item: ReleaseFallbackItem) => {
     if (!walletInfo?.address) {
@@ -111,7 +116,7 @@ export function ReleaseFundsFallback({
         provider,
       })
       toast.success(t('adminPending.approveSuccessShort', { title: item.milestoneTitle }))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       const message = err instanceof Error ? err.message : t('adminPending.approveFail')
       console.error('Approve milestone error:', err)
@@ -145,7 +150,7 @@ export function ReleaseFundsFallback({
         provider,
       })
       toast.success(t('adminPending.releaseSuccess', { title: item.milestoneTitle }))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       const message = err instanceof Error ? err.message : t('adminPending.releaseFail')
       console.error('Release funds error:', err)
@@ -161,7 +166,7 @@ export function ReleaseFundsFallback({
     try {
       await syncDealFromIndexer(item.dealId, item.escrowContractAddress)
       toast.success(t('adminPending.resyncSuccess'))
-      window.location.reload()
+      await completeCommand()
     } catch (err) {
       console.error(err)
       toast.error(
@@ -186,6 +191,7 @@ export function ReleaseFundsFallback({
         onOpenChange={(next) => {
           if (!next) setDisputeTarget(null)
         }}
+        onAfterCommand={completeCommand}
       />
       {items.map((item) => {
         const escrow = escrowsByContractId.get(item.escrowContractAddress)

--- a/components/deals/deal-repayment-panel.tsx
+++ b/components/deals/deal-repayment-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { toast } from 'sonner'
 import { ExternalLink, RefreshCw } from 'lucide-react'
@@ -15,6 +15,7 @@ import { formatDate } from '@/lib/date-utils'
 import { useI18n } from '@/lib/i18n/provider'
 import { useWallet } from '@/hooks/use-wallet'
 import { useRepaymentEscrow } from '@/hooks/use-repayment-escrow'
+import { useRepaymentCommandRefresh } from '@/hooks/use-repayment-command-refresh'
 import {
   computeRepaymentState,
   canFund as canFundCheck,
@@ -58,6 +59,12 @@ export function DealRepaymentPanel({
   const [addAmount, setAddAmount] = useState('')
   const backgroundSyncDone = useRef(false)
 
+  const refreshDeal = useCallback(async () => {
+    const updated = await fetchDeal()
+    if (updated) onDealUpdate(updated)
+  }, [fetchDeal, onDealUpdate])
+  const { refreshAfterCommand } = useRepaymentCommandRefresh(refreshDeal)
+
   const {
     status,
     displayStatus,
@@ -69,8 +76,6 @@ export function DealRepaymentPanel({
     defaultFundAmount,
     breakdown,
   } = computeRepaymentState(deal)
-
-  if (deal.status === 'awaiting_funding') return null
 
   const canFund = canFundCheck(isPyme, deal.escrowAddress, status)
   const canRelease = canReleaseCheck(
@@ -88,22 +93,19 @@ export function DealRepaymentPanel({
     status,
   )
 
-  const refresh = async () => {
-    const updated = await fetchDeal()
-    if (updated) onDealUpdate(updated)
-  }
-
   useEffect(() => {
     if (!deal.escrowAddress || backgroundSyncDone.current) return
     backgroundSyncDone.current = true
     void syncDealFromIndexer(deal.id, deal.escrowAddress, undefined, {
       retryOnEmptyMilestones: false,
     })
-      .then(() => refresh())
+      .then(() => refreshAfterCommand())
       .catch(() => {
         // Non-blocking; user can refresh manually
       })
-  }, [deal.id, deal.escrowAddress, syncDealFromIndexer])
+  }, [deal.id, deal.escrowAddress, syncDealFromIndexer, refreshAfterCommand])
+
+  if (deal.status === 'awaiting_funding') return null
 
   const handleRefreshStatus = async () => {
     if (!deal.escrowAddress) return
@@ -112,7 +114,7 @@ export function DealRepaymentPanel({
       await syncDealFromIndexer(deal.id, deal.escrowAddress, undefined, {
         retryOnEmptyMilestones: true,
       })
-      await refresh()
+      await refreshAfterCommand()
       toast.success(t('dealDetail.repaymentRefreshSuccess'))
     } catch (err) {
       console.error(err)
@@ -140,7 +142,7 @@ export function DealRepaymentPanel({
         amount: parsed,
         provider,
       })
-      await refresh()
+      await refreshAfterCommand()
       setFundAmount('')
       toast.success(t('dealDetail.repaymentFunded'))
     } catch (err) {
@@ -166,7 +168,7 @@ export function DealRepaymentPanel({
         milestoneIndex: currentMilestone.index,
         provider,
       })
-      await refresh()
+      await refreshAfterCommand()
       toast.success(t('dealDetail.repaymentReleased'))
     } catch (err) {
       console.error(err)
@@ -192,7 +194,7 @@ export function DealRepaymentPanel({
         amount: parsed,
         provider,
       })
-      await refresh()
+      await refreshAfterCommand()
       setAddAmount('')
       toast.success(t('dealDetail.repaymentMilestoneAdded'))
     } catch (err) {

--- a/hooks/use-repayment-command-refresh.ts
+++ b/hooks/use-repayment-command-refresh.ts
@@ -1,0 +1,22 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+/** Shared post-command refresh: bump local data and revalidate RSC payloads. */
+export type AfterRepaymentCommand = () => void | Promise<void>
+
+export function useRepaymentCommandRefresh(
+  localRefresh?: AfterRepaymentCommand,
+) {
+  const router = useRouter()
+  const [epoch, setEpoch] = useState(0)
+
+  const refreshAfterCommand = useCallback(async () => {
+    setEpoch((n) => n + 1)
+    await localRefresh?.()
+    router.refresh()
+  }, [localRefresh, router])
+
+  return { epoch, refreshAfterCommand }
+}

--- a/hooks/use-repayment-escrow.ts
+++ b/hooks/use-repayment-escrow.ts
@@ -1,9 +1,9 @@
 'use client'
 
 /**
- * Deploy and manage Trustless Work multi-release repayment escrows.
- * Platform wallet holds all TW roles; investor is milestone receiver only.
- * Admin deploys / updates / releases; PyME micro-funds.
+ * Wire Trustless Work hooks, wallet transport, and UI busy state into the
+ * repayment command layer. Persistence, indexer retries, and payload
+ * construction live in `lib/deals/`.
  */
 
 import { useCallback, useMemo, useState } from 'react'
@@ -20,16 +20,6 @@ import {
   useGetEscrowFromIndexerByContractIds,
   useGetMultipleEscrowBalances,
 } from '@trustless-work/escrow/hooks'
-import type {
-  InitializeMultiReleaseEscrowPayload,
-  FundEscrowPayload,
-  MultiReleaseReleaseFundsPayload,
-  UpdateMultiReleaseEscrowPayload,
-  MultiReleaseMilestone,
-  MultiReleaseStartDisputePayload,
-  MultiReleaseResolveDisputePayload,
-  GetEscrowsFromIndexerResponse,
-} from '@trustless-work/escrow'
 import { signTransaction } from '@/lib/trustless/wallet-kit'
 import { usePollarSession } from '@/providers/pollar-provider'
 import { USDC_TRUSTLINE } from '@/lib/trustless/trustlines'
@@ -37,31 +27,26 @@ import {
   MERCATO_PLATFORM_ADDRESS,
   repaymentEscrowRoles,
 } from '@/lib/trustless/config'
-import {
-  PLATFORM_FEE_PERCENT,
-  DEFAULT_FIRST_MILESTONE_PERCENT,
-  repaymentEscrowAmount,
-  repaymentMilestoneAmount,
-  repaymentRemainingAmount,
-} from '@/lib/deals/fees'
-import { computeInvestorReturns } from '@/lib/deals/investor-metrics'
 import { createClient } from '@/lib/supabase/client'
-import type { RepaymentMilestoneCache, RepaymentStatus } from '@/lib/types'
-import {
-  repaymentEngagementId,
-  roundUsdc,
-  reconcileRepaymentFromIndexer,
-  cacheMilestonesFromIndexer,
-} from '@/lib/deals/repayment-escrow-helpers'
-import { fetchInvestorWalletForDeal } from '@/lib/deals/investor-wallet'
+import { cacheMilestonesFromIndexer } from '@/lib/deals/repayment-escrow-helpers'
+import { createRepaymentEscrowCommands } from '@/lib/deals/repayment-escrow-commands'
+import { createSupabaseDealRepository } from '@/lib/deals/repayment-escrow-reconcile'
 import type {
-  DeployRepaymentParams,
-  FundRepaymentParams,
-  ReleaseMilestoneParams,
   AddMilestoneParams,
+  DeployRepaymentParams,
   DisputeMilestoneParams,
+  FundRepaymentParams,
+  IndexerPort,
+  ReleaseMilestoneParams,
   ResolveDisputeParams,
+  SendTxResult,
+  SyncDealFromIndexerOptions,
+  TxTransport,
 } from '@/lib/deals/repayment-escrow-types'
+import {
+  DEFAULT_REPAYMENT_RETRY_POLICY,
+  defaultWait,
+} from '@/lib/deals/repayment-retry'
 
 export function useRepaymentEscrow() {
   const supabase = useMemo(() => createClient(), [])
@@ -79,564 +64,163 @@ export function useRepaymentEscrow() {
   const pollar = usePollarSession()
   const [isWorking, setIsWorking] = useState(false)
 
-  const signAndSend = useCallback(
-    async (unsignedTransaction: string, address: string, provider: string | null) => {
-      if (provider === 'pollar') {
-        return pollar.signAndSubmitTx(unsignedTransaction)
-      }
-      const signedXdr = await signTransaction({ unsignedTransaction, address })
-      if (!signedXdr) throw new Error('Failed to sign transaction')
-      const txResult = await sendTransaction(signedXdr)
-      if (txResult.status !== 'SUCCESS') {
-        throw new Error(
-          'message' in txResult
-            ? (txResult as { message: string }).message
-            : 'Transaction submission failed',
-        )
-      }
-      return undefined
-    },
+  const transport: TxTransport = useMemo(
+    () => ({
+      async signAndSend(unsignedTransaction, address, provider) {
+        if (provider === 'pollar') {
+          await pollar.signAndSubmitTx(unsignedTransaction)
+          return undefined
+        }
+        const signedXdr = await signTransaction({
+          unsignedTransaction,
+          address,
+        })
+        if (!signedXdr) throw new Error('Failed to sign transaction')
+        const txResult = await sendTransaction(signedXdr)
+        if (txResult.status !== 'SUCCESS') {
+          throw new Error(
+            'message' in txResult
+              ? (txResult as { message: string }).message
+              : 'Transaction submission failed',
+          )
+        }
+        return txResult as SendTxResult
+      },
+    }),
     [pollar, sendTransaction],
   )
 
-  const fetchIndexerEscrow = useCallback(
-    async (contractId: string): Promise<GetEscrowsFromIndexerResponse | null> => {
-      const escrows = await getEscrowByContractIds({ contractIds: [contractId] })
-      return escrows?.[0] ?? null
-    },
-    [getEscrowByContractIds],
-  )
-
-  const syncDealFromIndexer = useCallback(
-    async (
-      dealId: string,
-      contractId: string,
-      extras?: Record<string, unknown>,
-      options?: { retryOnEmptyMilestones?: boolean },
-    ): Promise<{
-      milestones: RepaymentMilestoneCache[]
-      status: RepaymentStatus
-      balance: number
-    }> => {
-      const retryOnEmpty = options?.retryOnEmptyMilestones ?? true
-      let escrow = await fetchIndexerEscrow(contractId)
-      if (retryOnEmpty && !escrow?.milestones?.length) {
-        for (let attempt = 0; attempt < 2; attempt++) {
-          await new Promise((r) => setTimeout(r, 2000))
-          escrow = await fetchIndexerEscrow(contractId)
-          if (escrow?.milestones?.length) break
-        }
-      }
-      let balance = Number(escrow?.balance ?? 0)
-      try {
-        const balances = await getMultipleBalances({ addresses: [contractId] })
-        const bal = balances?.[0]?.balance
-        if (bal != null && Number.isFinite(Number(bal))) {
-          balance = Number(bal)
-        }
-      } catch {
-        // Indexer balance is fine as fallback
-      }
-      const { data: dealRow } = await supabase
-        .from('deals')
-        .select('repayment_total_amount')
-        .eq('id', dealId)
-        .single()
-      const totalGrossed = Number(dealRow?.repayment_total_amount ?? 0)
-      const { milestones, status } = reconcileRepaymentFromIndexer(
-        escrow,
-        balance,
-        totalGrossed,
-      )
-      const { error } = await supabase
-        .from('deals')
-        .update({
-          repayment_milestones: milestones,
-          repayment_status: status,
-          escrow_status:
-            status === 'released'
-              ? 'completed'
-              : status === 'escrow_initialized'
-                ? 'initialized'
-                : 'active',
-          ...(status === 'released'
-            ? {
-                status: 'completed',
-                completed_at: new Date().toISOString(),
-              }
-            : {}),
-          ...extras,
+  const indexer: IndexerPort = useMemo(
+    () => ({
+      async getByContractId(contractId) {
+        const escrows = await getEscrowByContractIds({
+          contractIds: [contractId],
         })
-        .eq('id', dealId)
-      if (error) throw error
-      return { milestones, status, balance }
-    },
-    [fetchIndexerEscrow, getMultipleBalances, supabase],
+        return escrows?.[0] ?? null
+      },
+      getBySigner(signer) {
+        return getEscrowsBySigner({ signer })
+      },
+      async getBalance(contractId) {
+        try {
+          const balances = await getMultipleBalances({
+            addresses: [contractId],
+          })
+          const bal = balances?.[0]?.balance
+          if (bal != null && Number.isFinite(Number(bal))) {
+            return Number(bal)
+          }
+        } catch {
+          // Indexer balance is fine as fallback
+        }
+        return null
+      },
+    }),
+    [getEscrowByContractIds, getEscrowsBySigner, getMultipleBalances],
   )
 
-  const deployRepaymentEscrow = useCallback(
-    async (params: DeployRepaymentParams): Promise<{ contractId: string }> => {
-      if (!MERCATO_PLATFORM_ADDRESS) {
-        throw new Error('Platform address not configured')
-      }
-      if (!USDC_TRUSTLINE.address) {
-        throw new Error('USDC trustline not configured')
-      }
+  const deals = useMemo(
+    () => createSupabaseDealRepository(supabase),
+    [supabase],
+  )
 
-      const investor =
-        params.investorAddress?.trim() ||
-        (await fetchInvestorWalletForDeal(supabase, params.dealId))
-      if (!investor) {
-        throw new Error('Investor wallet address is required')
-      }
-
-      setIsWorking(true)
-      try {
-        const { profit } = computeInvestorReturns(
-          params.principal,
-          params.aprPercent,
-          params.termDays,
-        )
-        const totalGrossed = repaymentEscrowAmount(params.principal, profit)
-        const firstPercent =
-          params.firstMilestonePercent ?? DEFAULT_FIRST_MILESTONE_PERCENT
-        const firstAmount = repaymentMilestoneAmount(totalGrossed, firstPercent)
-        if (firstAmount <= 0) {
-          throw new Error('First milestone amount must be positive')
-        }
-
-        const engagementId = repaymentEngagementId(params.dealId)
-        // Platform holds every TW role; investor is milestone receiver only.
-        const roles = repaymentEscrowRoles()
-
-        const payload: InitializeMultiReleaseEscrowPayload = {
-          signer: params.adminAddress,
-          engagementId,
-          title: `Repayment · ${params.productName}`,
-          description: `SMB multi-release repayment for deal ${params.dealId}`,
-          roles,
-          platformFee: PLATFORM_FEE_PERCENT,
+  const commands = useMemo(
+    () =>
+      createRepaymentEscrowCommands({
+        builder: {
+          initialize: deployEscrow,
+          fund: fundEscrow,
+          approveMilestone,
+          releaseFunds,
+          updateEscrow,
+          startDispute,
+          resolveDispute,
+        },
+        transport,
+        indexer,
+        deals,
+        config: {
+          platformAddress: MERCATO_PLATFORM_ADDRESS,
           trustline: {
             address: USDC_TRUSTLINE.address,
             symbol: USDC_TRUSTLINE.symbol,
           },
-          milestones: [
-            {
-              description: `Repayment milestone 1 (${firstPercent}%)`,
-              amount: firstAmount,
-              receiver: investor,
-            },
-          ],
-        }
-
-        const deployResponse = await deployEscrow(payload, 'multi-release')
-        if (deployResponse.status !== 'SUCCESS' || !deployResponse.unsignedTransaction) {
-          throw new Error('Failed to create repayment escrow transaction')
-        }
-
-        let contractId: string | undefined
-
-        if (params.provider === 'pollar') {
-          await pollar.signAndSubmitTx(deployResponse.unsignedTransaction)
-          for (let attempt = 0; attempt < 5; attempt++) {
-            if (attempt > 0) await new Promise((r) => setTimeout(r, 3000))
-            try {
-              const escrows = await getEscrowsBySigner({
-                signer: params.adminAddress,
-              })
-              const match = escrows.find((e) => e.engagementId === engagementId)
-              if (match?.contractId) {
-                contractId = match.contractId
-                break
-              }
-            } catch {
-              // Indexer lag — retry
-            }
-          }
-        } else {
-          const signedXdr = await signTransaction({
-            unsignedTransaction: deployResponse.unsignedTransaction,
-            address: params.adminAddress,
-          })
-          if (!signedXdr) throw new Error('Failed to sign transaction')
-          const txResult = await sendTransaction(signedXdr)
-          if (txResult.status !== 'SUCCESS') {
-            throw new Error(
-              'message' in txResult
-                ? (txResult as { message: string }).message
-                : 'Transaction submission failed',
-            )
-          }
-          const escrowResponse = txResult as {
-            contractId?: string
-            escrow?: { contractId?: string }
-          }
-          contractId =
-            escrowResponse.contractId ?? escrowResponse.escrow?.contractId
-        }
-
-        if (!contractId) {
-          throw new Error('Repayment escrow contract ID was not confirmed')
-        }
-
-        const initialMilestones: RepaymentMilestoneCache[] = [
-          {
-            index: 0,
-            description: `Repayment milestone 1 (${firstPercent}%)`,
-            amount: firstAmount,
-            released: false,
-          },
-        ]
-
-        // Keep repayment_due_at from delivery confirmation; only backfill if missing
-        const { data: existingDeal } = await supabase
-          .from('deals')
-          .select('repayment_due_at')
-          .eq('id', params.dealId)
-          .single()
-
-        const updates: Record<string, unknown> = {
-          escrow_id: engagementId,
-          escrow_contract_address: contractId,
-          escrow_status: 'initialized',
-          repayment_status: 'escrow_initialized',
-          repayment_total_amount: totalGrossed,
-          repayment_milestones: initialMilestones,
-        }
-
-        if (!existingDeal?.repayment_due_at) {
-          const dueAt = new Date()
-          dueAt.setDate(dueAt.getDate() + Math.max(1, params.termDays))
-          updates.repayment_due_at = dueAt.toISOString()
-        }
-
-        const { error } = await supabase
-          .from('deals')
-          .update(updates)
-          .eq('id', params.dealId)
-
-        if (error) throw error
-
-        return { contractId }
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [deployEscrow, getEscrowsBySigner, pollar, sendTransaction, supabase],
+          roles: repaymentEscrowRoles,
+        },
+        wait: defaultWait,
+        retry: DEFAULT_REPAYMENT_RETRY_POLICY,
+      }),
+    [
+      approveMilestone,
+      deals,
+      deployEscrow,
+      fundEscrow,
+      indexer,
+      releaseFunds,
+      resolveDispute,
+      startDispute,
+      transport,
+      updateEscrow,
+    ],
   )
 
+  const run = useCallback(async <T>(op: () => Promise<T>) => {
+    setIsWorking(true)
+    try {
+      return await op()
+    } finally {
+      setIsWorking(false)
+    }
+  }, [])
+
+  const deployRepaymentEscrow = useCallback(
+    (params: DeployRepaymentParams) =>
+      run(() => commands.deployRepaymentEscrow(params)),
+    [commands, run],
+  )
   const fundRepaymentEscrow = useCallback(
-    async (params: FundRepaymentParams) => {
-      setIsWorking(true)
-      try {
-        const amount = roundUsdc(params.amount)
-        if (amount <= 0) throw new Error('Fund amount must be positive')
-
-        const payload: FundEscrowPayload = {
-          contractId: params.contractId,
-          signer: params.pymeAddress,
-          amount,
-        }
-        const fundResponse = await fundEscrow(payload, 'multi-release')
-        if (fundResponse.status !== 'SUCCESS' || !fundResponse.unsignedTransaction) {
-          throw new Error('Failed to build repayment fund transaction')
-        }
-        await signAndSend(
-          fundResponse.unsignedTransaction,
-          params.pymeAddress,
-          params.provider,
-        )
-
-        // Brief indexer lag allowance
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [fundEscrow, signAndSend, syncDealFromIndexer],
+    (params: FundRepaymentParams) =>
+      run(() => commands.fundRepaymentEscrow(params)),
+    [commands, run],
   )
-
   const approveRepaymentMilestone = useCallback(
-    async (params: ReleaseMilestoneParams) => {
-      setIsWorking(true)
-      try {
-        const approveResponse = await approveMilestone(
-          {
-            contractId: params.contractId,
-            milestoneIndex: String(params.milestoneIndex),
-            approver: params.releaseSigner,
-          },
-          'multi-release',
-        )
-        if (
-          approveResponse.status !== 'SUCCESS' ||
-          !approveResponse.unsignedTransaction
-        ) {
-          throw new Error('Failed to build approve transaction')
-        }
-        await signAndSend(
-          approveResponse.unsignedTransaction,
-          params.releaseSigner,
-          params.provider,
-        )
-        await new Promise((r) => setTimeout(r, 1000))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [approveMilestone, signAndSend, syncDealFromIndexer],
+    (params: ReleaseMilestoneParams) =>
+      run(() => commands.approveRepaymentMilestone(params)),
+    [commands, run],
   )
-
   const releaseRepaymentMilestone = useCallback(
-    async (params: ReleaseMilestoneParams) => {
-      setIsWorking(true)
-      try {
-        const releasePayload: MultiReleaseReleaseFundsPayload = {
-          contractId: params.contractId,
-          releaseSigner: params.releaseSigner,
-          milestoneIndex: String(params.milestoneIndex),
-        }
-        const releaseResponse = await releaseFunds(releasePayload, 'multi-release')
-        if (
-          releaseResponse.status !== 'SUCCESS' ||
-          !releaseResponse.unsignedTransaction
-        ) {
-          throw new Error('Failed to build release transaction')
-        }
-        await signAndSend(
-          releaseResponse.unsignedTransaction,
-          params.releaseSigner,
-          params.provider,
-        )
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [releaseFunds, signAndSend, syncDealFromIndexer],
+    (params: ReleaseMilestoneParams) =>
+      run(() => commands.releaseRepaymentMilestone(params)),
+    [commands, run],
   )
-
   const approveAndReleaseMilestone = useCallback(
-    async (params: ReleaseMilestoneParams) => {
-      setIsWorking(true)
-      try {
-        const indexStr = String(params.milestoneIndex)
-        const approveResponse = await approveMilestone(
-          {
-            contractId: params.contractId,
-            milestoneIndex: indexStr,
-            approver: params.releaseSigner,
-          },
-          'multi-release',
-        )
-        if (
-          approveResponse.status !== 'SUCCESS' ||
-          !approveResponse.unsignedTransaction
-        ) {
-          throw new Error('Failed to build approve transaction')
-        }
-        await signAndSend(
-          approveResponse.unsignedTransaction,
-          params.releaseSigner,
-          params.provider,
-        )
-
-        const releasePayload: MultiReleaseReleaseFundsPayload = {
-          contractId: params.contractId,
-          releaseSigner: params.releaseSigner,
-          milestoneIndex: indexStr,
-        }
-        const releaseResponse = await releaseFunds(releasePayload, 'multi-release')
-        if (
-          releaseResponse.status !== 'SUCCESS' ||
-          !releaseResponse.unsignedTransaction
-        ) {
-          throw new Error('Failed to build release transaction')
-        }
-        await signAndSend(
-          releaseResponse.unsignedTransaction,
-          params.releaseSigner,
-          params.provider,
-        )
-
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [approveMilestone, releaseFunds, signAndSend, syncDealFromIndexer],
+    (params: ReleaseMilestoneParams) =>
+      run(() => commands.approveAndReleaseMilestone(params)),
+    [commands, run],
   )
-
   const addRepaymentMilestone = useCallback(
-    async (params: AddMilestoneParams) => {
-      if (!MERCATO_PLATFORM_ADDRESS) {
-        throw new Error('Platform address not configured')
-      }
-      setIsWorking(true)
-      try {
-        const escrow = await fetchIndexerEscrow(params.contractId)
-        if (!escrow) throw new Error('Escrow not found in indexer')
-
-        const existing = cacheMilestonesFromIndexer(escrow)
-        const { data: dealRow } = await supabase
-          .from('deals')
-          .select('repayment_total_amount')
-          .eq('id', params.dealId)
-          .single()
-
-        const totalGrossed = Number(dealRow?.repayment_total_amount ?? 0)
-        const scheduled = existing.map((m) => m.amount)
-        const remaining = repaymentRemainingAmount(totalGrossed, scheduled)
-        const amount = roundUsdc(params.amount ?? remaining)
-        if (amount <= 0) {
-          throw new Error('No remaining repayment amount to schedule')
-        }
-        if (totalGrossed > 0 && amount > remaining + 0.01) {
-          throw new Error(
-            `Milestone amount exceeds remaining (${remaining} USDC)`,
-          )
-        }
-
-        const investor =
-          params.investorAddress?.trim() ||
-          (await fetchInvestorWalletForDeal(supabase, params.dealId))
-        if (!investor) {
-          throw new Error('Investor wallet address is required')
-        }
-
-        const nextIndex = existing.length
-        const newMilestone = {
-          description:
-            params.description?.trim() ||
-            `Repayment milestone ${nextIndex + 1}`,
-          amount,
-          receiver: investor,
-        }
-
-        // Keep investor as receiver only; normalize operational roles to platform.
-        const roles = repaymentEscrowRoles()
-
-        const updatePayload: UpdateMultiReleaseEscrowPayload = {
-          contractId: params.contractId,
-          signer: params.adminAddress,
-          escrow: {
-            engagementId: escrow.engagementId,
-            title: escrow.title,
-            description: escrow.description,
-            roles,
-            platformFee: escrow.platformFee,
-            trustline: escrow.trustline,
-            milestones: [
-              ...escrow.milestones.map((m) => {
-                const multi = m as MultiReleaseMilestone
-                return {
-                  description: multi.description,
-                  amount: Number(multi.amount ?? 0),
-                  receiver: multi.receiver || investor,
-                  status: multi.status,
-                  flags: multi.flags,
-                }
-              }),
-              newMilestone,
-            ],
-            isActive: escrow.isActive ?? true,
-          },
-        }
-
-        const updateResponse = await updateEscrow(updatePayload, 'multi-release')
-        if (
-          updateResponse.status !== 'SUCCESS' ||
-          !updateResponse.unsignedTransaction
-        ) {
-          throw new Error('Failed to build update escrow transaction')
-        }
-        await signAndSend(
-          updateResponse.unsignedTransaction,
-          params.adminAddress,
-          params.provider,
-        )
-
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [fetchIndexerEscrow, signAndSend, supabase, syncDealFromIndexer, updateEscrow],
+    (params: AddMilestoneParams) =>
+      run(() => commands.addRepaymentMilestone(params)),
+    [commands, run],
   )
-
-  /**
-   * Opens a milestone dispute. Signer must not be the disputeResolver.
-   * With platform as serviceProvider, the platform wallet can open disputes
-   * only when MERCATO_DISPUTE_RESOLVER_ADDRESS is a different address.
-   */
   const startRepaymentDispute = useCallback(
-    async (params: DisputeMilestoneParams) => {
-      setIsWorking(true)
-      try {
-        const payload: MultiReleaseStartDisputePayload = {
-          contractId: params.contractId,
-          signer: params.signer,
-          milestoneIndex: String(params.milestoneIndex),
-        }
-        const response = await startDispute(payload, 'multi-release')
-        if (response.status !== 'SUCCESS' || !response.unsignedTransaction) {
-          throw new Error('Failed to build start-dispute transaction')
-        }
-        await signAndSend(
-          response.unsignedTransaction,
-          params.signer,
-          params.provider,
-        )
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [signAndSend, startDispute, syncDealFromIndexer],
+    (params: DisputeMilestoneParams) =>
+      run(() => commands.startRepaymentDispute(params)),
+    [commands, run],
   )
-
   const resolveRepaymentDispute = useCallback(
-    async (params: ResolveDisputeParams) => {
-      setIsWorking(true)
-      try {
-        const cleaned = params.distributions
-          .map((d) => ({
-            address: d.address.trim(),
-            amount: roundUsdc(d.amount),
-          }))
-          .filter((d) => d.address && d.amount > 0)
-        if (cleaned.length === 0) {
-          throw new Error('At least one positive distribution is required')
-        }
-
-        const payload: MultiReleaseResolveDisputePayload = {
-          contractId: params.contractId,
-          disputeResolver: params.disputeResolver,
-          milestoneIndex: String(params.milestoneIndex),
-          distributions: cleaned as MultiReleaseResolveDisputePayload['distributions'],
-        }
-        const response = await resolveDispute(payload, 'multi-release')
-        if (response.status !== 'SUCCESS' || !response.unsignedTransaction) {
-          throw new Error('Failed to build resolve-dispute transaction')
-        }
-        await signAndSend(
-          response.unsignedTransaction,
-          params.disputeResolver,
-          params.provider,
-        )
-        await new Promise((r) => setTimeout(r, 1500))
-        await syncDealFromIndexer(params.dealId, params.contractId)
-      } finally {
-        setIsWorking(false)
-      }
-    },
-    [resolveDispute, signAndSend, syncDealFromIndexer],
+    (params: ResolveDisputeParams) =>
+      run(() => commands.resolveRepaymentDispute(params)),
+    [commands, run],
+  )
+  const syncDealFromIndexer = useCallback(
+    (
+      dealId: string,
+      contractId: string,
+      extras?: Record<string, unknown>,
+      options?: SyncDealFromIndexerOptions,
+    ) => commands.syncDealFromIndexer(dealId, contractId, extras, options),
+    [commands],
   )
 
   return {

--- a/hooks/use-wallet-persistence.ts
+++ b/hooks/use-wallet-persistence.ts
@@ -11,6 +11,7 @@ import {
   saveStoredWallet,
   type ConnectedWallet,
 } from '@/lib/mercato-wallet'
+import { resolveSignupUserType } from '@/lib/profile/onboarding'
 
 export function useWalletPersistence() {
   const supabase = useMemo(() => createClient(), [])
@@ -112,14 +113,7 @@ export function useWalletPersistence() {
         return
       }
 
-      const metaType = user.user_metadata?.user_type
-      const user_type =
-        metaType === 'pyme' ||
-        metaType === 'investor' ||
-        metaType === 'supplier' ||
-        metaType === 'admin'
-          ? metaType
-          : 'pyme'
+      const user_type = resolveSignupUserType(user.user_metadata?.user_type)
 
       const baseRow = {
         wallet_provider: wallet.provider,

--- a/lib/admin/admin-audit.ts
+++ b/lib/admin/admin-audit.ts
@@ -2,7 +2,12 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import type { AdminAuditEvent, AdminAuditFilters, AdminAuditResult } from './types'
 
 /** Actions written by the admin mutation RPCs. Single source for filters/labels. */
-export const AUDIT_ACTIONS = ['verify', 'unverify', 'update_profile'] as const
+export const AUDIT_ACTIONS = [
+  'verify',
+  'unverify',
+  'update_profile',
+  'set_user_type',
+] as const
 
 export const AUDIT_PAGE_SIZE = 25
 

--- a/lib/deals/repayment-escrow-commands.ts
+++ b/lib/deals/repayment-escrow-commands.ts
@@ -1,0 +1,352 @@
+import { syncDealFromIndexer } from '@/lib/deals/repayment-escrow-reconcile'
+import {
+  buildApprovePayload,
+  buildFundPayload,
+  buildReleasePayload,
+  buildResolveDisputePayload,
+  buildStartDisputePayload,
+  contractIdFromSendResult,
+  planAddMilestone,
+  planRepaymentDeploy,
+  repaymentDueAtIso,
+  requireUnsigned,
+  sendFailureMessage,
+} from '@/lib/deals/repayment-escrow-payloads'
+import type {
+  AddMilestoneParams,
+  DealRepository,
+  DeployRepaymentParams,
+  DisputeMilestoneParams,
+  EscrowBuilder,
+  FundRepaymentParams,
+  IndexerPort,
+  ReleaseMilestoneParams,
+  RepaymentEscrowConfig,
+  ResolveDisputeParams,
+  SyncDealFromIndexerOptions,
+  TxTransport,
+} from '@/lib/deals/repayment-escrow-types'
+import {
+  DEFAULT_REPAYMENT_RETRY_POLICY,
+  type RetryPolicy,
+  type WaitFn,
+} from '@/lib/deals/repayment-retry'
+
+export type RepaymentEscrowCommandDeps = {
+  builder: EscrowBuilder
+  transport: TxTransport
+  indexer: IndexerPort
+  deals: DealRepository
+  config: RepaymentEscrowConfig
+  wait: WaitFn
+  retry?: RetryPolicy
+  now?: () => Date
+}
+
+export function createRepaymentEscrowCommands(deps: RepaymentEscrowCommandDeps) {
+  const policy = deps.retry ?? DEFAULT_REPAYMENT_RETRY_POLICY
+  const now = deps.now ?? (() => new Date())
+
+  const sync = (
+    dealId: string,
+    contractId: string,
+    extras?: Record<string, unknown>,
+    options?: SyncDealFromIndexerOptions,
+  ) =>
+    syncDealFromIndexer(
+      deps.indexer,
+      deps.deals,
+      deps.wait,
+      policy,
+      dealId,
+      contractId,
+      extras,
+      options,
+    )
+
+  async function afterCommand(
+    delayMs: number,
+    dealId: string,
+    contractId: string,
+  ) {
+    if (delayMs > 0) await deps.wait(delayMs)
+    await sync(dealId, contractId)
+  }
+
+  async function deployRepaymentEscrow(
+    params: DeployRepaymentParams,
+  ): Promise<{ contractId: string }> {
+    if (!deps.config.platformAddress) {
+      throw new Error('Platform address not configured')
+    }
+    if (!deps.config.trustline.address) {
+      throw new Error('USDC trustline not configured')
+    }
+
+    const investor =
+      params.investorAddress?.trim() ||
+      (await deps.deals.resolveInvestorWallet(params.dealId))
+    if (!investor) {
+      throw new Error('Investor wallet address is required')
+    }
+
+    const planned = planRepaymentDeploy({
+      params,
+      investorAddress: investor,
+      roles: deps.config.roles(),
+      trustline: deps.config.trustline,
+    })
+
+    const deployResponse = await deps.builder.initialize(
+      planned.payload,
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      deployResponse,
+      'Failed to create repayment escrow transaction',
+    )
+
+    let contractId: string | undefined
+
+    if (params.provider === 'pollar') {
+      await deps.transport.signAndSend(
+        unsigned,
+        params.adminAddress,
+        params.provider,
+      )
+      const { attempts, delayMs } = policy.pollarContractLookup
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        if (attempt > 0) await deps.wait(delayMs)
+        try {
+          const escrows = await deps.indexer.getBySigner(params.adminAddress)
+          const match = escrows.find(
+            (e) => e.engagementId === planned.engagementId,
+          )
+          if (match?.contractId) {
+            contractId = match.contractId
+            break
+          }
+        } catch {
+          // Indexer lag — retry
+        }
+      }
+    } else {
+      const txResult = await deps.transport.signAndSend(
+        unsigned,
+        params.adminAddress,
+        params.provider,
+      )
+      if (txResult && txResult.status !== 'SUCCESS') {
+        throw new Error(sendFailureMessage(txResult))
+      }
+      contractId = contractIdFromSendResult(txResult)
+    }
+
+    if (!contractId) {
+      throw new Error('Repayment escrow contract ID was not confirmed')
+    }
+
+    const existingDueAt = await deps.deals.getRepaymentDueAt(params.dealId)
+    const updates: Record<string, unknown> = {
+      escrow_id: planned.engagementId,
+      escrow_contract_address: contractId,
+      escrow_status: 'initialized',
+      repayment_status: 'escrow_initialized',
+      repayment_total_amount: planned.totalGrossed,
+      repayment_milestones: planned.initialMilestones,
+    }
+    if (!existingDueAt) {
+      updates.repayment_due_at = repaymentDueAtIso(params.termDays, now())
+    }
+    await deps.deals.updateDeal(params.dealId, updates)
+
+    return { contractId }
+  }
+
+  async function fundRepaymentEscrow(params: FundRepaymentParams) {
+    const payload = buildFundPayload(params)
+    const fundResponse = await deps.builder.fund(payload, 'multi-release')
+    const unsigned = requireUnsigned(
+      fundResponse,
+      'Failed to build repayment fund transaction',
+    )
+    await deps.transport.signAndSend(
+      unsigned,
+      params.pymeAddress,
+      params.provider,
+    )
+    await afterCommand(policy.afterCommandMs.fund, params.dealId, params.contractId)
+  }
+
+  async function approveRepaymentMilestone(params: ReleaseMilestoneParams) {
+    const approveResponse = await deps.builder.approveMilestone(
+      buildApprovePayload(params),
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      approveResponse,
+      'Failed to build approve transaction',
+    )
+    await deps.transport.signAndSend(
+      unsigned,
+      params.releaseSigner,
+      params.provider,
+    )
+    await afterCommand(
+      policy.afterCommandMs.approve,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  async function releaseRepaymentMilestone(params: ReleaseMilestoneParams) {
+    const releaseResponse = await deps.builder.releaseFunds(
+      buildReleasePayload(params),
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      releaseResponse,
+      'Failed to build release transaction',
+    )
+    await deps.transport.signAndSend(
+      unsigned,
+      params.releaseSigner,
+      params.provider,
+    )
+    await afterCommand(
+      policy.afterCommandMs.release,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  async function approveAndReleaseMilestone(params: ReleaseMilestoneParams) {
+    const approvePayload = buildApprovePayload(params)
+    const approveResponse = await deps.builder.approveMilestone(
+      approvePayload,
+      'multi-release',
+    )
+    const approveUnsigned = requireUnsigned(
+      approveResponse,
+      'Failed to build approve transaction',
+    )
+    await deps.transport.signAndSend(
+      approveUnsigned,
+      params.releaseSigner,
+      params.provider,
+    )
+
+    const releaseResponse = await deps.builder.releaseFunds(
+      buildReleasePayload(params),
+      'multi-release',
+    )
+    const releaseUnsigned = requireUnsigned(
+      releaseResponse,
+      'Failed to build release transaction',
+    )
+    await deps.transport.signAndSend(
+      releaseUnsigned,
+      params.releaseSigner,
+      params.provider,
+    )
+
+    await afterCommand(
+      policy.afterCommandMs.approveAndRelease,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  async function addRepaymentMilestone(params: AddMilestoneParams) {
+    if (!deps.config.platformAddress) {
+      throw new Error('Platform address not configured')
+    }
+    const escrow = await deps.indexer.getByContractId(params.contractId)
+    if (!escrow) throw new Error('Escrow not found in indexer')
+
+    const totalGrossed = await deps.deals.getRepaymentTotal(params.dealId)
+    const investor =
+      params.investorAddress?.trim() ||
+      (await deps.deals.resolveInvestorWallet(params.dealId))
+    if (!investor) {
+      throw new Error('Investor wallet address is required')
+    }
+
+    const { updatePayload } = planAddMilestone({
+      params,
+      escrow,
+      totalGrossed,
+      investorAddress: investor,
+      roles: deps.config.roles(),
+    })
+
+    const updateResponse = await deps.builder.updateEscrow(
+      updatePayload,
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      updateResponse,
+      'Failed to build update escrow transaction',
+    )
+    await deps.transport.signAndSend(
+      unsigned,
+      params.adminAddress,
+      params.provider,
+    )
+    await afterCommand(
+      policy.afterCommandMs.addMilestone,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  async function startRepaymentDispute(params: DisputeMilestoneParams) {
+    const response = await deps.builder.startDispute(
+      buildStartDisputePayload(params),
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      response,
+      'Failed to build start-dispute transaction',
+    )
+    await deps.transport.signAndSend(unsigned, params.signer, params.provider)
+    await afterCommand(
+      policy.afterCommandMs.dispute,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  async function resolveRepaymentDispute(params: ResolveDisputeParams) {
+    const response = await deps.builder.resolveDispute(
+      buildResolveDisputePayload(params),
+      'multi-release',
+    )
+    const unsigned = requireUnsigned(
+      response,
+      'Failed to build resolve-dispute transaction',
+    )
+    await deps.transport.signAndSend(
+      unsigned,
+      params.disputeResolver,
+      params.provider,
+    )
+    await afterCommand(
+      policy.afterCommandMs.resolveDispute,
+      params.dealId,
+      params.contractId,
+    )
+  }
+
+  return {
+    deployRepaymentEscrow,
+    fundRepaymentEscrow,
+    approveRepaymentMilestone,
+    releaseRepaymentMilestone,
+    approveAndReleaseMilestone,
+    addRepaymentMilestone,
+    startRepaymentDispute,
+    resolveRepaymentDispute,
+    syncDealFromIndexer: sync,
+  }
+}

--- a/lib/deals/repayment-escrow-payloads.ts
+++ b/lib/deals/repayment-escrow-payloads.ts
@@ -1,0 +1,255 @@
+import type {
+  FundEscrowPayload,
+  GetEscrowsFromIndexerResponse,
+  InitializeMultiReleaseEscrowPayload,
+  MultiReleaseMilestone,
+  MultiReleaseReleaseFundsPayload,
+  MultiReleaseResolveDisputePayload,
+  MultiReleaseStartDisputePayload,
+  UpdateMultiReleaseEscrowPayload,
+} from '@trustless-work/escrow'
+import {
+  DEFAULT_FIRST_MILESTONE_PERCENT,
+  PLATFORM_FEE_PERCENT,
+  repaymentEscrowAmount,
+  repaymentMilestoneAmount,
+  repaymentRemainingAmount,
+} from '@/lib/deals/fees'
+import { computeInvestorReturns } from '@/lib/deals/investor-metrics'
+import {
+  cacheMilestonesFromIndexer,
+  repaymentEngagementId,
+  roundUsdc,
+} from '@/lib/deals/repayment-escrow-helpers'
+import type {
+  AddMilestoneParams,
+  DeployRepaymentParams,
+  DisputeMilestoneParams,
+  EscrowBuildResult,
+  EscrowTrustline,
+  FundRepaymentParams,
+  ReleaseMilestoneParams,
+  RepaymentEscrowRoles,
+  ResolveDisputeParams,
+  SendTxResult,
+} from '@/lib/deals/repayment-escrow-types'
+import type { RepaymentMilestoneCache } from '@/lib/types'
+
+export function requireUnsigned(
+  result: EscrowBuildResult,
+  failMessage: string,
+): string {
+  if (result.status !== 'SUCCESS' || !result.unsignedTransaction) {
+    throw new Error(failMessage)
+  }
+  return result.unsignedTransaction
+}
+
+export function contractIdFromSendResult(
+  result: SendTxResult | undefined,
+): string | undefined {
+  if (!result) return undefined
+  return result.contractId ?? result.escrow?.contractId
+}
+
+export function sendFailureMessage(result: SendTxResult): string {
+  return 'message' in result && typeof result.message === 'string'
+    ? result.message
+    : 'Transaction submission failed'
+}
+
+export function planRepaymentDeploy(input: {
+  params: DeployRepaymentParams
+  investorAddress: string
+  roles: RepaymentEscrowRoles
+  trustline: EscrowTrustline
+}): {
+  payload: InitializeMultiReleaseEscrowPayload
+  totalGrossed: number
+  engagementId: string
+  initialMilestones: RepaymentMilestoneCache[]
+} {
+  const { params, investorAddress, roles, trustline } = input
+  const { profit } = computeInvestorReturns(
+    params.principal,
+    params.aprPercent,
+    params.termDays,
+  )
+  const totalGrossed = repaymentEscrowAmount(params.principal, profit)
+  const firstPercent =
+    params.firstMilestonePercent ?? DEFAULT_FIRST_MILESTONE_PERCENT
+  const firstAmount = repaymentMilestoneAmount(totalGrossed, firstPercent)
+  if (firstAmount <= 0) {
+    throw new Error('First milestone amount must be positive')
+  }
+
+  const engagementId = repaymentEngagementId(params.dealId)
+  const description = `Repayment milestone 1 (${firstPercent}%)`
+  const payload: InitializeMultiReleaseEscrowPayload = {
+    signer: params.adminAddress,
+    engagementId,
+    title: `Repayment · ${params.productName}`,
+    description: `SMB multi-release repayment for deal ${params.dealId}`,
+    roles,
+    platformFee: PLATFORM_FEE_PERCENT,
+    trustline: {
+      address: trustline.address,
+      symbol: trustline.symbol,
+    },
+    milestones: [
+      {
+        description,
+        amount: firstAmount,
+        receiver: investorAddress,
+      },
+    ],
+  }
+
+  return {
+    payload,
+    totalGrossed,
+    engagementId,
+    initialMilestones: [
+      {
+        index: 0,
+        description,
+        amount: firstAmount,
+        released: false,
+      },
+    ],
+  }
+}
+
+export function buildFundPayload(
+  params: FundRepaymentParams,
+): FundEscrowPayload {
+  const amount = roundUsdc(params.amount)
+  if (amount <= 0) throw new Error('Fund amount must be positive')
+  return {
+    contractId: params.contractId,
+    signer: params.pymeAddress,
+    amount,
+  }
+}
+
+export function buildApprovePayload(params: ReleaseMilestoneParams) {
+  return {
+    contractId: params.contractId,
+    milestoneIndex: String(params.milestoneIndex),
+    approver: params.releaseSigner,
+  }
+}
+
+export function buildReleasePayload(
+  params: ReleaseMilestoneParams,
+): MultiReleaseReleaseFundsPayload {
+  return {
+    contractId: params.contractId,
+    releaseSigner: params.releaseSigner,
+    milestoneIndex: String(params.milestoneIndex),
+  }
+}
+
+export function buildStartDisputePayload(
+  params: DisputeMilestoneParams,
+): MultiReleaseStartDisputePayload {
+  return {
+    contractId: params.contractId,
+    signer: params.signer,
+    milestoneIndex: String(params.milestoneIndex),
+  }
+}
+
+export function cleanDistributions(
+  distributions: ResolveDisputeParams['distributions'],
+): MultiReleaseResolveDisputePayload['distributions'] {
+  const cleaned = distributions
+    .map((d) => ({
+      address: d.address.trim(),
+      amount: roundUsdc(d.amount),
+    }))
+    .filter((d) => d.address && d.amount > 0)
+  if (cleaned.length === 0) {
+    throw new Error('At least one positive distribution is required')
+  }
+  return cleaned as MultiReleaseResolveDisputePayload['distributions']
+}
+
+export function buildResolveDisputePayload(
+  params: ResolveDisputeParams,
+): MultiReleaseResolveDisputePayload {
+  return {
+    contractId: params.contractId,
+    disputeResolver: params.disputeResolver,
+    milestoneIndex: String(params.milestoneIndex),
+    distributions: cleanDistributions(params.distributions),
+  }
+}
+
+export function planAddMilestone(input: {
+  params: AddMilestoneParams
+  escrow: GetEscrowsFromIndexerResponse
+  totalGrossed: number
+  investorAddress: string
+  roles: RepaymentEscrowRoles
+}): {
+  updatePayload: UpdateMultiReleaseEscrowPayload
+  amount: number
+} {
+  const { params, escrow, totalGrossed, investorAddress, roles } = input
+  const existing = cacheMilestonesFromIndexer(escrow)
+  const remaining = repaymentRemainingAmount(
+    totalGrossed,
+    existing.map((m) => m.amount),
+  )
+  const amount = roundUsdc(params.amount ?? remaining)
+  if (amount <= 0) {
+    throw new Error('No remaining repayment amount to schedule')
+  }
+  if (totalGrossed > 0 && amount > remaining + 0.01) {
+    throw new Error(`Milestone amount exceeds remaining (${remaining} USDC)`)
+  }
+
+  const nextIndex = existing.length
+  const newMilestone = {
+    description:
+      params.description?.trim() || `Repayment milestone ${nextIndex + 1}`,
+    amount,
+    receiver: investorAddress,
+  }
+
+  const updatePayload: UpdateMultiReleaseEscrowPayload = {
+    contractId: params.contractId,
+    signer: params.adminAddress,
+    escrow: {
+      engagementId: escrow.engagementId,
+      title: escrow.title,
+      description: escrow.description,
+      roles,
+      platformFee: escrow.platformFee,
+      trustline: escrow.trustline,
+      milestones: [
+        ...escrow.milestones.map((m) => {
+          const multi = m as MultiReleaseMilestone
+          return {
+            description: multi.description,
+            amount: Number(multi.amount ?? 0),
+            receiver: multi.receiver || investorAddress,
+            status: multi.status,
+            flags: multi.flags,
+          }
+        }),
+        newMilestone,
+      ],
+      isActive: escrow.isActive ?? true,
+    },
+  }
+
+  return { updatePayload, amount }
+}
+
+export function repaymentDueAtIso(termDays: number, now: Date): string {
+  const dueAt = new Date(now.getTime())
+  dueAt.setDate(dueAt.getDate() + Math.max(1, termDays))
+  return dueAt.toISOString()
+}

--- a/lib/deals/repayment-escrow-reconcile.ts
+++ b/lib/deals/repayment-escrow-reconcile.ts
@@ -1,0 +1,95 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { fetchInvestorWalletForDeal } from '@/lib/deals/investor-wallet'
+import { reconcileRepaymentFromIndexer } from '@/lib/deals/repayment-escrow-helpers'
+import type {
+  DealRepository,
+  IndexerPort,
+  SyncDealFromIndexerOptions,
+  SyncDealFromIndexerResult,
+} from '@/lib/deals/repayment-escrow-types'
+import type { RetryPolicy, WaitFn } from '@/lib/deals/repayment-retry'
+
+export function createSupabaseDealRepository(
+  supabase: SupabaseClient,
+): DealRepository {
+  return {
+    async getRepaymentDueAt(dealId) {
+      const { data } = await supabase
+        .from('deals')
+        .select('repayment_due_at')
+        .eq('id', dealId)
+        .single()
+      return data?.repayment_due_at ?? null
+    },
+    async getRepaymentTotal(dealId) {
+      const { data } = await supabase
+        .from('deals')
+        .select('repayment_total_amount')
+        .eq('id', dealId)
+        .single()
+      return Number(data?.repayment_total_amount ?? 0)
+    },
+    async updateDeal(dealId, patch) {
+      const { error } = await supabase.from('deals').update(patch).eq('id', dealId)
+      if (error) throw error
+    },
+    resolveInvestorWallet(dealId) {
+      return fetchInvestorWalletForDeal(supabase, dealId)
+    },
+  }
+}
+
+export async function syncDealFromIndexer(
+  indexer: IndexerPort,
+  deals: DealRepository,
+  wait: WaitFn,
+  policy: RetryPolicy,
+  dealId: string,
+  contractId: string,
+  extras?: Record<string, unknown>,
+  options?: SyncDealFromIndexerOptions,
+): Promise<SyncDealFromIndexerResult> {
+  const retryOnEmpty = options?.retryOnEmptyMilestones ?? true
+  let escrow = await indexer.getByContractId(contractId)
+  if (retryOnEmpty && !escrow?.milestones?.length) {
+    const { extraAttempts, delayMs } = policy.indexerEmptyMilestones
+    for (let attempt = 0; attempt < extraAttempts; attempt++) {
+      await wait(delayMs)
+      escrow = await indexer.getByContractId(contractId)
+      if (escrow?.milestones?.length) break
+    }
+  }
+  let balance = Number(escrow?.balance ?? 0)
+  try {
+    const lookedUp = await indexer.getBalance(contractId)
+    if (lookedUp != null) {
+      balance = lookedUp
+    }
+  } catch {
+    // Indexer balance is fine as fallback
+  }
+  const totalGrossed = await deals.getRepaymentTotal(dealId)
+  const { milestones, status } = reconcileRepaymentFromIndexer(
+    escrow,
+    balance,
+    totalGrossed,
+  )
+  await deals.updateDeal(dealId, {
+    repayment_milestones: milestones,
+    repayment_status: status,
+    escrow_status:
+      status === 'released'
+        ? 'completed'
+        : status === 'escrow_initialized'
+          ? 'initialized'
+          : 'active',
+    ...(status === 'released'
+      ? {
+          status: 'completed',
+          completed_at: new Date().toISOString(),
+        }
+      : {}),
+    ...extras,
+  })
+  return { milestones, status, balance }
+}

--- a/lib/deals/repayment-escrow-types.ts
+++ b/lib/deals/repayment-escrow-types.ts
@@ -1,3 +1,14 @@
+import type {
+  FundEscrowPayload,
+  GetEscrowsFromIndexerResponse,
+  InitializeMultiReleaseEscrowPayload,
+  MultiReleaseReleaseFundsPayload,
+  MultiReleaseResolveDisputePayload,
+  MultiReleaseStartDisputePayload,
+  UpdateMultiReleaseEscrowPayload,
+} from '@trustless-work/escrow'
+import type { RepaymentMilestoneCache, RepaymentStatus } from '@/lib/types'
+
 export interface DeployRepaymentParams {
   dealId: string
   /** Platform / admin wallet that signs deploy. */
@@ -57,4 +68,103 @@ export interface ResolveDisputeParams {
   /** Must sum to the milestone amount (post-fee rules enforced on-chain). */
   distributions: Array<{ address: string; amount: number }>
   provider: string | null
+}
+
+export type RepaymentEscrowRoles = {
+  approver: string
+  serviceProvider: string
+  platformAddress: string
+  releaseSigner: string
+  disputeResolver: string
+}
+
+export type EscrowBuildResult = {
+  status: string
+  unsignedTransaction?: string
+}
+
+export type SendTxResult = {
+  status: string
+  message?: string
+  contractId?: string
+  escrow?: { contractId?: string }
+}
+
+export type EscrowTrustline = {
+  address: string
+  symbol: string
+}
+
+export interface RepaymentEscrowConfig {
+  platformAddress: string
+  trustline: EscrowTrustline
+  roles: () => RepaymentEscrowRoles
+}
+
+export interface EscrowBuilder {
+  initialize(
+    payload: InitializeMultiReleaseEscrowPayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  fund(
+    payload: FundEscrowPayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  approveMilestone(
+    payload: {
+      contractId: string
+      milestoneIndex: string
+      approver: string
+    },
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  releaseFunds(
+    payload: MultiReleaseReleaseFundsPayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  updateEscrow(
+    payload: UpdateMultiReleaseEscrowPayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  startDispute(
+    payload: MultiReleaseStartDisputePayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+  resolveDispute(
+    payload: MultiReleaseResolveDisputePayload,
+    type: 'multi-release',
+  ): Promise<EscrowBuildResult>
+}
+
+export interface TxTransport {
+  signAndSend(
+    unsignedTransaction: string,
+    address: string,
+    provider: string | null,
+  ): Promise<SendTxResult | undefined>
+}
+
+export interface IndexerPort {
+  getByContractId(
+    contractId: string,
+  ): Promise<GetEscrowsFromIndexerResponse | null>
+  getBySigner(signer: string): Promise<GetEscrowsFromIndexerResponse[]>
+  getBalance(contractId: string): Promise<number | null>
+}
+
+export interface DealRepository {
+  getRepaymentDueAt(dealId: string): Promise<string | null>
+  getRepaymentTotal(dealId: string): Promise<number>
+  updateDeal(dealId: string, patch: Record<string, unknown>): Promise<void>
+  resolveInvestorWallet(dealId: string): Promise<string | null>
+}
+
+export type SyncDealFromIndexerResult = {
+  milestones: RepaymentMilestoneCache[]
+  status: RepaymentStatus
+  balance: number
+}
+
+export type SyncDealFromIndexerOptions = {
+  retryOnEmptyMilestones?: boolean
 }

--- a/lib/deals/repayment-retry.ts
+++ b/lib/deals/repayment-retry.ts
@@ -1,0 +1,35 @@
+export type RetryPolicy = {
+  indexerEmptyMilestones: { extraAttempts: number; delayMs: number }
+  pollarContractLookup: { attempts: number; delayMs: number }
+  afterCommandMs: {
+    fund: number
+    approve: number
+    release: number
+    addMilestone: number
+    dispute: number
+    resolveDispute: number
+    approveAndRelease: number
+  }
+}
+
+/** Matches the delays previously hardcoded in `useRepaymentEscrow`. */
+export const DEFAULT_REPAYMENT_RETRY_POLICY: RetryPolicy = {
+  indexerEmptyMilestones: { extraAttempts: 2, delayMs: 2000 },
+  pollarContractLookup: { attempts: 5, delayMs: 3000 },
+  afterCommandMs: {
+    fund: 1500,
+    approve: 1000,
+    release: 1500,
+    addMilestone: 1500,
+    dispute: 1500,
+    resolveDispute: 1500,
+    approveAndRelease: 1500,
+  },
+}
+
+export type WaitFn = (ms: number) => Promise<void>
+
+export const defaultWait: WaitFn = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })

--- a/lib/profile/onboarding.ts
+++ b/lib/profile/onboarding.ts
@@ -9,3 +9,13 @@ export function needsOnboarding(userType: string | null | undefined): boolean {
 export function isOnboardingUserType(value: string): value is OnboardingUserType {
   return value === 'pyme' || value === 'investor' || value === 'supplier'
 }
+
+/**
+ * Allowlist used by `public.handle_new_user()`. `admin` and unknown values
+ * become null so signup metadata cannot create an administrator profile.
+ */
+export function resolveSignupUserType(meta: unknown): OnboardingUserType | null {
+  if (typeof meta !== 'string') return null
+  const trimmed = meta.trim()
+  return isOnboardingUserType(trimmed) ? trimmed : null
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1717,7 +1717,8 @@
     "actionLabels": {
       "verify": "Verified",
       "unverify": "Verification removed",
-      "update_profile": "Profile updated"
+      "update_profile": "Profile updated",
+      "set_user_type": "Role updated"
     },
     "entityLabels": {
       "profile": "Profile",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1717,7 +1717,8 @@
     "actionLabels": {
       "verify": "Verificado",
       "unverify": "Verificación removida",
-      "update_profile": "Perfil actualizado"
+      "update_profile": "Perfil actualizado",
+      "set_user_type": "Rol actualizado"
     },
     "entityLabels": {
       "profile": "Perfil",

--- a/supabase/migrations/20260827000100_reject_admin_signup_metadata.sql
+++ b/supabase/migrations/20260827000100_reject_admin_signup_metadata.sql
@@ -1,0 +1,132 @@
+-- Signup metadata must not be able to create administrator profiles.
+-- handle_new_user() is security definer and previously accepted 'admin'
+-- from raw_user_meta_data before the update-time privileged-field trigger.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  meta_type text := nullif(trim(coalesce(new.raw_user_meta_data->>'user_type', '')), '');
+  resolved_type text;
+  v_referred_by uuid;
+begin
+  -- Onboarding roles only. 'admin' is ignored the same way as unknown values.
+  if meta_type in ('pyme', 'investor', 'supplier') then
+    resolved_type := meta_type;
+  else
+    resolved_type := null;
+  end if;
+
+  if new.raw_user_meta_data->>'referred_by_supplier_id' is not null then
+    begin
+      v_referred_by := (new.raw_user_meta_data->>'referred_by_supplier_id')::uuid;
+      if not exists (select 1 from public.supplier_companies where id = v_referred_by) then
+        v_referred_by := null;
+      end if;
+    exception when others then
+      v_referred_by := null;
+    end;
+  end if;
+
+  insert into public.profiles (
+    id,
+    email,
+    user_type,
+    company_name,
+    contact_name,
+    full_name,
+    referred_by_supplier_id
+  )
+  values (
+    new.id,
+    new.email,
+    resolved_type,
+    coalesce(new.raw_user_meta_data->>'company_name', null),
+    coalesce(new.raw_user_meta_data->>'contact_name', new.raw_user_meta_data->>'full_name', null),
+    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'contact_name', null),
+    v_referred_by
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+-- Client inserts (profiles_insert_own) can still supply user_type. Strip admin
+-- unless the writer is the service role (bootstrap / authorised provisioning).
+create or replace function public.enforce_profile_insert_privileged_fields()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if coalesce(auth.jwt() ->> 'role', '') = 'service_role' then
+    return new;
+  end if;
+
+  if new.user_type = 'admin' then
+    new.user_type := null;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_enforce_insert_privileged_fields on public.profiles;
+create trigger profiles_enforce_insert_privileged_fields
+  before insert on public.profiles
+  for each row
+  execute function public.enforce_profile_insert_privileged_fields();
+
+-- Authorised administrator provisioning. Existing admins (or SQL as service
+-- role for the first admin) assign roles; signup metadata cannot.
+create or replace function public.admin_set_user_type(
+  p_profile_id uuid,
+  p_user_type text,
+  p_reason text default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_admin uuid := assert_admin();
+  v_before text;
+  v_audit uuid;
+begin
+  if p_user_type is null or p_user_type not in ('pyme', 'investor', 'supplier', 'admin') then
+    raise exception 'invalid_user_type' using errcode = '22023';
+  end if;
+
+  select user_type into v_before from profiles where id = p_profile_id for update;
+  if not found then
+    raise exception 'not_found' using errcode = 'P0002';
+  end if;
+
+  update profiles
+    set user_type = p_user_type, updated_at = now()
+    where id = p_profile_id;
+
+  insert into admin_audit_events
+    (admin_user_id, action, entity_type, entity_id, before, after, reason)
+  values (
+    v_admin,
+    'set_user_type',
+    'profile',
+    p_profile_id::text,
+    jsonb_build_object('user_type', v_before),
+    jsonb_build_object('user_type', p_user_type),
+    nullif(trim(coalesce(p_reason, '')), '')
+  )
+  returning id into v_audit;
+
+  return v_audit;
+end;
+$$;
+
+revoke execute on function public.admin_set_user_type(uuid, text, text) from anon;


### PR DESCRIPTION
## Summary
- Signup metadata and client profile inserts can no longer create a profile with `user_type = 'admin'`. Permitted onboarding roles (`pyme`, `investor`, `supplier`) still apply. Administrator assignment is only available through the authorised `admin_set_user_type` RPC (`POST /api/admin/users/[id]/role`).
- Repayment escrow orchestration is no longer owned by the 655-line `useRepaymentEscrow` React hook. Deploy, fund, approve, release, add-milestone, start-dispute, and resolve-dispute run through a framework-independent command layer with injected adapters. Indexer reads, retry policy, balance lookup, and Supabase persistence live in a reconcile service. Admin and deal screens refresh local data after commands instead of calling `window.location.reload()`.

## Why
`public.handle_new_user()` is a `security definer` function invoked by `on_auth_user_created`. It previously accepted `raw_user_meta_data ->> 'user_type'` including `admin` at insert time. The privileged-field trigger only ran on **update**, so a signup request could mint an administrator profile before that guard applied. Client inserts (`profiles_insert_own` / wallet persistence) had the same hole.

`hooks/use-repayment-escrow.ts` mixed Trustless Work payload construction, wallet-specific signing, indexer polling with hardcoded `setTimeout` delays, Supabase reads/writes, fee math, and UI busy state. `PendingApprovals` and `DealRepaymentPanel` then duplicated post-command refresh (full page reloads). Core repayment behaviour could not be unit-tested without React and wallet dependencies, and any repayment transition was high risk.

## What changed

### #170 — Prevent signup metadata from creating administrator profiles
- New migration `20260827000100_reject_admin_signup_metadata.sql` redefines `handle_new_user()` so only `pyme`, `investor`, and `supplier` are taken from signup metadata. `admin` and unknown values become `null` (same as an empty role, so onboarding still runs).
- A before-insert trigger strips `user_type = 'admin'` unless the writer is `service_role`, so `profiles_insert_own` cannot escalate either.
- `admin_set_user_type` (asserts admin, writes `admin_audit_events`) plus `POST /api/admin/users/[id]/role` is the authorised provisioning path. First-admin bootstrap remains service-role SQL, which the existing update trigger already allows.
- `resolveSignupUserType()` mirrors the SQL allowlist and is used by wallet-persistence inserts.

### #175 — Separate repayment escrow orchestration from the React hook
- Command layer: `lib/deals/repayment-escrow-commands.ts` + payload builders in `lib/deals/repayment-escrow-payloads.ts`.
- Reconcile/persist: `lib/deals/repayment-escrow-reconcile.ts` (indexer snapshot, optional empty-milestone retry, balance lookup, deal row update).
- Retry timing: `lib/deals/repayment-retry.ts` (`DEFAULT_REPAYMENT_RETRY_POLICY` keeps the previous delays: 2000ms indexer empty retries, 3000ms Pollar contract lookup, 1500ms post-fund/release, 1000ms post-approve).
- `useRepaymentEscrow` only wires Trustless Work hooks, Pollar / Stellar Wallets Kit transport, Supabase, and `isWorking`.
- Shared `useRepaymentCommandRefresh` revalidates RSC data and local indexer/deal state. Signing still uses Pollar `signAndSubmitTx` or SWK `signTransaction` + `sendTransaction`. Status transitions are unchanged.

## How it was tested
- `bun test` — 299 pass, 0 fail
- Signup / role tests (`__tests__/profile/onboarding.test.ts`, `__tests__/admin/set-user-type-route.test.ts`):
  - `user_type = 'admin'` (including casing/whitespace) does not resolve to admin
  - `pyme`, `investor`, `supplier` still resolve
  - migration SQL no longer allowlists `admin` on signup
  - non-admins cannot call the role API; unknown roles are rejected; `admin_set_user_type` is invoked with the exact RPC arguments
- Repayment tests (`__tests__/deals/repayment-escrow-payloads.test.ts`, `repayment-escrow-commands.test.ts`, `repayment-escrow-reconcile.test.ts`):
  - initialize/fund/approve/release/dispute payloads
  - SWK deploy takes contract id from the send result; Pollar deploy looks up by engagement id with the configured delay
  - fund/approve/release wait the previous hardcoded indexer-lag delays before reconcile
  - empty-milestone indexer retry uses the policy; `retryOnEmptyMilestones: false` skips it
  - signer address is the provided wallet (dispute opener vs resolver)

## Test plan
- [x] Sign up with `user_metadata.user_type = 'admin'` and confirm the profile is not admin (onboarding still required)
- [x] Sign up / onboard as pyme, investor, and supplier
- [x] As an existing admin, `POST /api/admin/users/:id/role` with `{ "userType": "admin" }` succeeds and writes a `set_user_type` audit event
- [x] Admin approvals: deploy, approve, release, add milestone — page data refreshes without a full reload
- [x] Deal repayment panel: fund / release / add milestone refreshes local deal state
- [x] Pollar vs Stellar Wallets Kit signing paths still match the previous requirements
- [x] Retry delays match the previous hardcoded values and are configurable via `DEFAULT_REPAYMENT_RETRY_POLICY`

Closes #170
Closes #175


<img width="1162" height="781" alt="image" src="https://github.com/user-attachments/assets/bde5396f-30ee-4f47-aff0-91be380b9cdc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can update user roles with validation and audit tracking.
  * Added English and Spanish labels for role-change activity.
* **Security**
  * Signup information can no longer create administrator profiles.
  * Administrator roles can only be assigned through authorized administrative actions.
* **Bug Fixes**
  * Repayment escrow screens now refresh automatically after approvals, releases, disputes, funding, and milestone updates.
  * Improved escrow transaction handling, synchronization, retries, and balance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->