### PR TITLE
feat: 160 supplier referral invitation attribution

### DIFF
--- a/__tests__/referrals/lifecycle-events.test.ts
+++ b/__tests__/referrals/lifecycle-events.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+import type { ReferralEventType } from '@/lib/referrals/types'
+import { groupReferralActivityItems } from '@/lib/referrals/activity-grouping'
+
+const FUNNEL_EVENTS: ReferralEventType[] = [
+  'invitation_created',
+  'link_opened',
+  'signup_started',
+  'account_created',
+  'onboarding_completed',
+  'invitation_revoked',
+]
+
+describe('referral invitation lifecycle events', () => {
+  test('includes signup_started and invitation_revoked in the funnel set', () => {
+    expect(FUNNEL_EVENTS).toContain('signup_started')
+    expect(FUNNEL_EVENTS).toContain('invitation_revoked')
+  })
+
+  test('activity grouping still collapses consecutive link_opened events', () => {
+    const grouped = groupReferralActivityItems([
+      {
+        id: '1',
+        eventType: 'link_opened',
+        createdAt: '2026-01-01T00:00:00Z',
+        profileId: null,
+        invitationId: 'inv-1',
+        metadata: {},
+      },
+      {
+        id: '2',
+        eventType: 'link_opened',
+        createdAt: '2026-01-01T00:01:00Z',
+        profileId: null,
+        invitationId: 'inv-1',
+        metadata: {},
+      },
+      {
+        id: '3',
+        eventType: 'signup_started',
+        createdAt: '2026-01-01T00:02:00Z',
+        profileId: null,
+        invitationId: 'inv-1',
+        metadata: {},
+      },
+    ])
+
+    expect(grouped).toHaveLength(2)
+    expect(grouped[0]?.eventType).toBe('link_opened')
+    expect(grouped[0]?.groupedOpenCount).toBe(2)
+    expect(grouped[1]?.eventType).toBe('signup_started')
+  })
+})

--- a/app/api/referral/invitations/[id]/regenerate/route.ts
+++ b/app/api/referral/invitations/[id]/regenerate/route.ts
@@ -51,6 +51,15 @@ export async function POST(request: Request, context: RouteContext) {
     })
     .eq('id', id)
 
+  const service = createServiceClient()
+  await logReferralEvent(service, {
+    supplierCompanyId: existing.supplier_company_id,
+    invitationId: id,
+    eventType: 'invitation_revoked',
+    profileId: user.id,
+    metadata: { reason: 'regenerated' },
+  })
+
   const token = generateInviteToken()
   const tokenHash = hashInviteToken(token)
   const origin = new URL(request.url).origin
@@ -73,7 +82,6 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({ error: error?.message ?? 'Failed to regenerate' }, { status: 500 })
   }
 
-  const service = createServiceClient()
   await logReferralEvent(service, {
     supplierCompanyId: existing.supplier_company_id,
     invitationId: invitation.id,

--- a/app/api/referral/invitations/[id]/regenerate/route.ts
+++ b/app/api/referral/invitations/[id]/regenerate/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({ error: 'Cannot regenerate a converted invitation' }, { status: 400 })
   }
 
-  await supabase
+  const { data: revoked, error: revokeError } = await supabase
     .from('supplier_referral_invitations')
     .update({
       status: 'revoked',
@@ -50,15 +50,34 @@ export async function POST(request: Request, context: RouteContext) {
       updated_at: new Date().toISOString(),
     })
     .eq('id', id)
+    .in('status', ['active', 'expired'])
+    .select('id')
+    .maybeSingle()
 
-  const service = createServiceClient()
-  await logReferralEvent(service, {
-    supplierCompanyId: existing.supplier_company_id,
-    invitationId: id,
-    eventType: 'invitation_revoked',
-    profileId: user.id,
-    metadata: { reason: 'regenerated' },
-  })
+  if (revokeError) {
+    return NextResponse.json({ error: 'Failed to regenerate invitation' }, { status: 500 })
+  }
+
+  if (!revoked && existing.status === 'active') {
+    return NextResponse.json({ error: 'Failed to regenerate invitation' }, { status: 409 })
+  }
+
+  let service: ReturnType<typeof createServiceClient> | null = null
+  try {
+    service = createServiceClient()
+  } catch (err) {
+    console.error('[referral] service client unavailable for regenerate events', err)
+  }
+
+  if (revoked && service) {
+    await logReferralEvent(service, {
+      supplierCompanyId: existing.supplier_company_id,
+      invitationId: id,
+      eventType: 'invitation_revoked',
+      profileId: user.id,
+      metadata: { reason: 'regenerated' },
+    })
+  }
 
   const token = generateInviteToken()
   const tokenHash = hashInviteToken(token)
@@ -79,15 +98,17 @@ export async function POST(request: Request, context: RouteContext) {
     .single()
 
   if (error || !invitation) {
-    return NextResponse.json({ error: error?.message ?? 'Failed to regenerate' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to regenerate invitation' }, { status: 500 })
   }
 
-  await logReferralEvent(service, {
-    supplierCompanyId: existing.supplier_company_id,
-    invitationId: invitation.id,
-    eventType: 'invitation_created',
-    metadata: { regeneratedFrom: id },
-  })
+  if (service) {
+    await logReferralEvent(service, {
+      supplierCompanyId: existing.supplier_company_id,
+      invitationId: invitation.id,
+      eventType: 'invitation_created',
+      metadata: { regeneratedFrom: id },
+    })
+  }
 
   return NextResponse.json({ id: invitation.id, inviteUrl })
 }

--- a/app/api/referral/invitations/[id]/revoke/route.ts
+++ b/app/api/referral/invitations/[id]/revoke/route.ts
@@ -1,11 +1,17 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { logReferralEvent } from '@/lib/referrals/log-event'
 
 export const dynamic = 'force-dynamic'
 
 type RouteContext = { params: Promise<{ id: string }> }
 
-async function getOwnedInvitation(supabase: Awaited<ReturnType<typeof createClient>>, userId: string, id: string) {
+async function getOwnedInvitation(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  id: string,
+) {
   const { data: companies } = await supabase
     .from('supplier_companies')
     .select('id')
@@ -24,7 +30,7 @@ async function getOwnedInvitation(supabase: Awaited<ReturnType<typeof createClie
   return data
 }
 
-export async function POST(request: Request, context: RouteContext) {
+export async function POST(_request: Request, context: RouteContext) {
   const { id } = await context.params
   const supabase = await createClient()
   const {
@@ -45,6 +51,10 @@ export async function POST(request: Request, context: RouteContext) {
     return NextResponse.json({ error: 'Cannot revoke a converted invitation' }, { status: 400 })
   }
 
+  if (invitation.status === 'revoked') {
+    return NextResponse.json({ ok: true, alreadyRevoked: true })
+  }
+
   const { error } = await supabase
     .from('supplier_referral_invitations')
     .update({
@@ -53,10 +63,19 @@ export async function POST(request: Request, context: RouteContext) {
       updated_at: new Date().toISOString(),
     })
     .eq('id', id)
+    .eq('status', 'active')
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })
   }
+
+  const service = createServiceClient()
+  await logReferralEvent(service, {
+    supplierCompanyId: invitation.supplier_company_id,
+    invitationId: invitation.id,
+    eventType: 'invitation_revoked',
+    profileId: user.id,
+  })
 
   return NextResponse.json({ ok: true })
 }

--- a/app/api/referral/invitations/[id]/revoke/route.ts
+++ b/app/api/referral/invitations/[id]/revoke/route.ts
@@ -55,7 +55,7 @@ export async function POST(_request: Request, context: RouteContext) {
     return NextResponse.json({ ok: true, alreadyRevoked: true })
   }
 
-  const { error } = await supabase
+  const { data: revoked, error } = await supabase
     .from('supplier_referral_invitations')
     .update({
       status: 'revoked',
@@ -64,18 +64,28 @@ export async function POST(_request: Request, context: RouteContext) {
     })
     .eq('id', id)
     .eq('status', 'active')
+    .select('id')
+    .maybeSingle()
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to revoke invitation' }, { status: 500 })
   }
 
-  const service = createServiceClient()
-  await logReferralEvent(service, {
-    supplierCompanyId: invitation.supplier_company_id,
-    invitationId: invitation.id,
-    eventType: 'invitation_revoked',
-    profileId: user.id,
-  })
+  if (!revoked) {
+    return NextResponse.json({ ok: true, alreadyRevoked: true })
+  }
+
+  try {
+    const service = createServiceClient()
+    await logReferralEvent(service, {
+      supplierCompanyId: invitation.supplier_company_id,
+      invitationId: invitation.id,
+      eventType: 'invitation_revoked',
+      profileId: user.id,
+    })
+  } catch (err) {
+    console.error('[referral] invitation_revoked event skipped', err)
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/app/api/referral/invitations/route.ts
+++ b/app/api/referral/invitations/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Invalid company filter' }, { status: 403 })
   }
 
-  let query = supabase
+  const query = supabase
     .from('supplier_referral_invitations')
     .select(
       'id, supplier_company_id, label, recipient_email, status, expires_at, converted_profile_id, revoked_at, created_at, updated_at, supplier:supplier_companies(company_name)',
@@ -57,22 +57,29 @@ export async function GET(request: Request) {
 
   const invitationIds = (data ?? []).map((row) => row.id)
   const openCounts: Record<string, number> = {}
+  let opensAvailable = true
 
   if (invitationIds.length > 0) {
     try {
       const service = createServiceClient()
-      const { data: events } = await service
+      const { data: events, error: eventsError } = await service
         .from('referral_events')
         .select('invitation_id')
         .in('invitation_id', invitationIds)
         .eq('event_type', 'link_opened')
 
-      for (const ev of events ?? []) {
-        if (ev.invitation_id) {
-          openCounts[ev.invitation_id] = (openCounts[ev.invitation_id] ?? 0) + 1
+      if (eventsError) {
+        opensAvailable = false
+        console.error('[referral] link_opened counts unavailable', eventsError)
+      } else {
+        for (const ev of events ?? []) {
+          if (ev.invitation_id) {
+            openCounts[ev.invitation_id] = (openCounts[ev.invitation_id] ?? 0) + 1
+          }
         }
       }
     } catch (err) {
+      opensAvailable = false
       console.error('[referral] link_opened counts skipped', err)
     }
   }
@@ -90,11 +97,17 @@ export async function GET(request: Request) {
       convertedProfileId: row.converted_profile_id,
       revokedAt: row.revoked_at,
       createdAt: row.created_at,
-      linkOpenCount: openCounts[row.id] ?? 0,
+      linkOpenCount: opensAvailable ? (openCounts[row.id] ?? 0) : null,
     }
   })
 
-  return NextResponse.json({ data: rows, total: count ?? 0, page, pageSize })
+  return NextResponse.json({
+    data: rows,
+    total: count ?? 0,
+    page,
+    pageSize,
+    opensAvailable,
+  })
 }
 
 export async function POST(request: Request) {

--- a/app/api/referral/invitations/route.ts
+++ b/app/api/referral/invitations/route.ts
@@ -59,17 +59,21 @@ export async function GET(request: Request) {
   const openCounts: Record<string, number> = {}
 
   if (invitationIds.length > 0) {
-    const service = createServiceClient()
-    const { data: events } = await service
-      .from('referral_events')
-      .select('invitation_id')
-      .in('invitation_id', invitationIds)
-      .eq('event_type', 'link_opened')
+    try {
+      const service = createServiceClient()
+      const { data: events } = await service
+        .from('referral_events')
+        .select('invitation_id')
+        .in('invitation_id', invitationIds)
+        .eq('event_type', 'link_opened')
 
-    for (const ev of events ?? []) {
-      if (ev.invitation_id) {
-        openCounts[ev.invitation_id] = (openCounts[ev.invitation_id] ?? 0) + 1
+      for (const ev of events ?? []) {
+        if (ev.invitation_id) {
+          openCounts[ev.invitation_id] = (openCounts[ev.invitation_id] ?? 0) + 1
+        }
       }
+    } catch (err) {
+      console.error('[referral] link_opened counts skipped', err)
     }
   }
 
@@ -150,16 +154,22 @@ export async function POST(request: Request) {
     .single()
 
   if (error || !invitation) {
-    return NextResponse.json({ error: error?.message ?? 'Failed to create invitation' }, { status: 500 })
+    console.error('[referral] create invitation failed', error)
+    return NextResponse.json({ error: 'Failed to create invitation' }, { status: 500 })
   }
 
-  const service = createServiceClient()
-  await logReferralEvent(service, {
-    supplierCompanyId: body.supplierCompanyId,
-    invitationId: invitation.id,
-    eventType: 'invitation_created',
-    metadata: { label: body.label ?? null },
-  })
+  try {
+    const service = createServiceClient()
+    await logReferralEvent(service, {
+      supplierCompanyId: body.supplierCompanyId,
+      invitationId: invitation.id,
+      eventType: 'invitation_created',
+      metadata: { label: body.label ?? null },
+    })
+  } catch (err) {
+    // Invitation is already persisted; event logging must not fail the response.
+    console.error('[referral] invitation_created event skipped', err)
+  }
 
   return NextResponse.json({ id: invitation.id, inviteUrl })
 }

--- a/app/api/referral/invite/route.ts
+++ b/app/api/referral/invite/route.ts
@@ -12,14 +12,7 @@ export type ResolvedInvite = {
   companyName: string | null
 }
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url)
-  const token = searchParams.get('token')?.trim()
-
-  if (!token) {
-    return NextResponse.json({ error: 'Missing token' }, { status: 400 })
-  }
-
+async function resolveActiveInvite(token: string) {
   const supabase = createServiceClient()
   const tokenHash = hashInviteToken(token)
 
@@ -30,12 +23,41 @@ export async function GET(request: Request) {
     .maybeSingle()
 
   if (error || !invitation) {
-    return NextResponse.json({ error: 'Invitation not found' }, { status: 404 })
+    return { error: 'Invitation not found' as const, status: 404 as const }
   }
 
   if (!isInvitationActive(invitation.status, invitation.expires_at)) {
-    return NextResponse.json({ error: 'Invitation is no longer active' }, { status: 400 })
+    return { error: 'Invitation is no longer active' as const, status: 400 as const }
   }
+
+  const company = invitation.supplier as { company_name?: string | null } | null
+
+  return {
+    supabase,
+    invitation,
+    resolved: {
+      invitationId: invitation.id,
+      supplierCompanyId: invitation.supplier_company_id,
+      companyName: company?.company_name ?? null,
+    } satisfies ResolvedInvite,
+  }
+}
+
+/** Resolve opaque invite token; records link_opened. */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const token = searchParams.get('token')?.trim()
+
+  if (!token) {
+    return NextResponse.json({ error: 'Missing token' }, { status: 400 })
+  }
+
+  const result = await resolveActiveInvite(token)
+  if ('error' in result && result.error) {
+    return NextResponse.json({ error: result.error }, { status: result.status })
+  }
+
+  const { supabase, invitation, resolved } = result
 
   await logReferralEvent(supabase, {
     supplierCompanyId: invitation.supplier_company_id,
@@ -43,11 +65,37 @@ export async function GET(request: Request) {
     eventType: 'link_opened',
   })
 
-  const company = invitation.supplier as { company_name?: string | null } | null
+  return NextResponse.json(resolved)
+}
 
-  return NextResponse.json({
-    invitationId: invitation.id,
+/** Record signup_started when the referred user begins account creation. */
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as {
+    token?: string
+    event?: string
+  } | null
+
+  const token = body?.token?.trim()
+  if (!token) {
+    return NextResponse.json({ error: 'Missing token' }, { status: 400 })
+  }
+
+  if (body?.event && body.event !== 'signup_started') {
+    return NextResponse.json({ error: 'Unsupported event' }, { status: 400 })
+  }
+
+  const result = await resolveActiveInvite(token)
+  if ('error' in result && result.error) {
+    return NextResponse.json({ error: result.error }, { status: result.status })
+  }
+
+  const { supabase, invitation } = result
+
+  await logReferralEvent(supabase, {
     supplierCompanyId: invitation.supplier_company_id,
-    companyName: company?.company_name ?? null,
-  } satisfies ResolvedInvite)
+    invitationId: invitation.id,
+    eventType: 'signup_started',
+  })
+
+  return NextResponse.json({ ok: true })
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -20,6 +20,14 @@ export async function GET(request: NextRequest) {
           sameSite: 'lax',
         })
       }
+      const inviteToken = request.cookies.get('mercato-invite')?.value
+      if (inviteToken) {
+        response.cookies.set('mercato-invite', inviteToken, {
+          path: '/',
+          maxAge: 86400,
+          sameSite: 'lax',
+        })
+      }
       return response
     }
   }

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -63,6 +63,8 @@ function SignUpContent() {
             id: data.supplierCompanyId,
             company_name: data.companyName ?? 'Supplier',
           })
+          document.cookie = `mercato-invite=${encodeURIComponent(inviteToken)}; path=/; max-age=86400; samesite=lax`
+          document.cookie = `mercato-referral=${data.supplierCompanyId}; path=/; max-age=86400; samesite=lax`
         }
       })
       .catch(() => {})
@@ -87,6 +89,14 @@ function SignUpContent() {
     }
 
     try {
+      if (inviteToken) {
+        void fetch('/api/referral/invite', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: inviteToken, event: 'signup_started' }),
+        }).catch(() => {})
+      }
+
       const { error } = await supabase.auth.signUp({
         email,
         password,

--- a/components/referrals/invitations-section.tsx
+++ b/components/referrals/invitations-section.tsx
@@ -97,13 +97,30 @@ export function ReferralInvitationsSection({
           recipientEmail: recipientEmail.trim() || undefined,
         }),
       })
-      const data = await res.json()
-      if (!res.ok) throw new Error(data.error ?? 'Failed')
+      const raw = await res.text()
+      let data: { error?: string; inviteUrl?: string; id?: string } = {}
+      if (raw.trim()) {
+        try {
+          data = JSON.parse(raw) as typeof data
+        } catch {
+          throw new Error('Something went wrong. Please try again.')
+        }
+      }
+      if (!res.ok) {
+        throw new Error(
+          typeof data.error === 'string' && data.error.length > 0 && data.error.length < 120
+            ? data.error
+            : 'Could not create invitation. Please try again.',
+        )
+      }
+      if (!data.inviteUrl) {
+        throw new Error('Could not create invitation. Please try again.')
+      }
       setInviteUrl(data.inviteUrl)
       toast.success(labels.create)
       window.location.reload()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Error')
+      toast.error(err instanceof Error ? err.message : 'Could not create invitation. Please try again.')
     } finally {
       setCreating(false)
     }
@@ -163,7 +180,10 @@ export function ReferralInvitationsSection({
                 <select
                   value={companyId}
                   onChange={(e) => setCompanyId(e.target.value)}
-                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  className="flex h-10 w-full appearance-none rounded-md border border-input bg-background bg-[length:1rem] bg-[right_0.75rem_center] bg-no-repeat px-3 pr-10 text-sm"
+                  style={{
+                    backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+                  }}
                 >
                   {companies.map((c) => (
                     <option key={c.id} value={c.id}>{c.company_name ?? c.id}</option>

--- a/components/referrals/invitations-section.tsx
+++ b/components/referrals/invitations-section.tsx
@@ -101,7 +101,11 @@ export function ReferralInvitationsSection({
       let data: { error?: string; inviteUrl?: string; id?: string } = {}
       if (raw.trim()) {
         try {
-          data = JSON.parse(raw) as typeof data
+          const parsed: unknown = JSON.parse(raw)
+          if (!parsed || typeof parsed !== 'object') {
+            throw new Error('invalid')
+          }
+          data = parsed as typeof data
         } catch {
           throw new Error('Something went wrong. Please try again.')
         }
@@ -113,7 +117,7 @@ export function ReferralInvitationsSection({
             : 'Could not create invitation. Please try again.',
         )
       }
-      if (!data.inviteUrl) {
+      if (typeof data.inviteUrl !== 'string' || !data.inviteUrl) {
         throw new Error('Could not create invitation. Please try again.')
       }
       setInviteUrl(data.inviteUrl)

--- a/components/settings/settings-onboarding.tsx
+++ b/components/settings/settings-onboarding.tsx
@@ -23,6 +23,7 @@ import { useI18n } from '@/lib/i18n/provider'
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import type { ReferralSupplier } from '@/app/api/referral/route'
+import type { ResolvedInvite } from '@/app/api/referral/invite/route'
 
 const STEPS = ['role', 'profile', 'done'] as const
 type Step = (typeof STEPS)[number]
@@ -54,23 +55,19 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
     bio: '',
   })
 
-  const [inviteAttribution, setInviteAttribution] = useState<{
-    invitationId: string
-    supplierCompanyId: string
-  } | null>(null)
+  const [inviteAttribution, setInviteAttribution] = useState<ResolvedInvite | null>(null)
+  const [inviteResolveState, setInviteResolveState] = useState<'idle' | 'pending' | 'done'>('idle')
 
   useEffect(() => {
     const inviteMatch = document.cookie.match(/(?:^|;\s*)mercato-invite=([^;]+)/)
     const inviteToken = inviteMatch ? decodeURIComponent(inviteMatch[1]) : null
     if (inviteToken) {
+      setInviteResolveState('pending')
       fetch(`/api/referral/invite?token=${encodeURIComponent(inviteToken)}`)
         .then((r) => (r.ok ? r.json() : null))
-        .then((data: { invitationId?: string; supplierCompanyId?: string; companyName?: string | null } | null) => {
+        .then((data: ResolvedInvite | null) => {
           if (data?.invitationId && data.supplierCompanyId) {
-            setInviteAttribution({
-              invitationId: data.invitationId,
-              supplierCompanyId: data.supplierCompanyId,
-            })
+            setInviteAttribution(data)
             setReferral({
               id: data.supplierCompanyId,
               company_name: data.companyName ?? 'Supplier',
@@ -78,8 +75,11 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
           }
         })
         .catch(() => {})
+        .finally(() => setInviteResolveState('done'))
       return
     }
+
+    setInviteResolveState('done')
 
     const match = document.cookie.match(/(?:^|;\s*)mercato-referral=([^;]+)/)
     const referralId = match ? decodeURIComponent(match[1]) : null
@@ -204,6 +204,9 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
   }
 
   const handleFinish = async () => {
+    if (userType === 'pyme' && inviteResolveState === 'pending') {
+      return
+    }
     if (!validateProfile()) return
     const ok = await saveProfile()
     if (!ok) return
@@ -467,7 +470,7 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
               <Button type="button" variant="ghost" className="rounded-full" onClick={() => setStep('role')}>
                 {t('settings.onboarding.back')}
               </Button>
-              <Button className="rounded-full" size="lg" onClick={handleFinish} disabled={isSaving}>
+              <Button className="rounded-full" size="lg" onClick={handleFinish} disabled={isSaving || (userType === 'pyme' && inviteResolveState === 'pending')}>
                 {isSaving ? (
                   <>
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />

--- a/components/settings/settings-onboarding.tsx
+++ b/components/settings/settings-onboarding.tsx
@@ -54,7 +54,33 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
     bio: '',
   })
 
+  const [inviteAttribution, setInviteAttribution] = useState<{
+    invitationId: string
+    supplierCompanyId: string
+  } | null>(null)
+
   useEffect(() => {
+    const inviteMatch = document.cookie.match(/(?:^|;\s*)mercato-invite=([^;]+)/)
+    const inviteToken = inviteMatch ? decodeURIComponent(inviteMatch[1]) : null
+    if (inviteToken) {
+      fetch(`/api/referral/invite?token=${encodeURIComponent(inviteToken)}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: { invitationId?: string; supplierCompanyId?: string; companyName?: string | null } | null) => {
+          if (data?.invitationId && data.supplierCompanyId) {
+            setInviteAttribution({
+              invitationId: data.invitationId,
+              supplierCompanyId: data.supplierCompanyId,
+            })
+            setReferral({
+              id: data.supplierCompanyId,
+              company_name: data.companyName ?? 'Supplier',
+            })
+          }
+        })
+        .catch(() => {})
+      return
+    }
+
     const match = document.cookie.match(/(?:^|;\s*)mercato-referral=([^;]+)/)
     const referralId = match ? decodeURIComponent(match[1]) : null
     if (!referralId) return
@@ -124,6 +150,18 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
     if (!userType) return false
     setIsSaving(true)
     try {
+      const attribution =
+        userType === 'pyme'
+          ? inviteAttribution
+            ? {
+                referred_by_supplier_id: inviteAttribution.supplierCompanyId,
+                referral_invitation_id: inviteAttribution.invitationId,
+              }
+            : referral
+              ? { referred_by_supplier_id: referral.id }
+              : {}
+          : {}
+
       const { error } = await supabase
         .from('profiles')
         .update({
@@ -136,11 +174,17 @@ export function SettingsOnboarding({ userId, email, initialFullName = '' }: Sett
           sector: form.sector || null,
           bio: form.bio.trim() || null,
           updated_at: new Date().toISOString(),
-          ...(referral && userType === 'pyme' ? { referred_by_supplier_id: referral.id } : {}),
+          ...attribution,
         })
         .eq('id', userId)
 
       if (error) throw error
+
+      if (userType === 'pyme' && (inviteAttribution || referral)) {
+        document.cookie = 'mercato-invite=; path=/; max-age=0; samesite=lax'
+        document.cookie = 'mercato-referral=; path=/; max-age=0; samesite=lax'
+      }
+
       return true
     } catch (err) {
       console.error(err)

--- a/lib/referrals/types.ts
+++ b/lib/referrals/types.ts
@@ -3,8 +3,10 @@ export type ReferralInvitationStatus = 'active' | 'revoked' | 'expired' | 'conve
 export type ReferralEventType =
   | 'invitation_created'
   | 'link_opened'
+  | 'signup_started'
   | 'account_created'
   | 'onboarding_completed'
+  | 'invitation_revoked'
   | 'deal_created'
   | 'deal_funded'
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -3128,8 +3128,10 @@
       "events": {
         "invitation_created": "Invitation created",
         "link_opened": "Link opened",
+        "signup_started": "Signup started",
         "account_created": "Account created",
         "onboarding_completed": "Onboarding completed",
+        "invitation_revoked": "Invitation revoked",
         "deal_created": "Deal created",
         "deal_funded": "Deal funded"
       }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3128,8 +3128,10 @@
       "events": {
         "invitation_created": "Invitación creada",
         "link_opened": "Link abierto",
+        "signup_started": "Registro iniciado",
         "account_created": "Cuenta creada",
         "onboarding_completed": "Onboarding completado",
+        "invitation_revoked": "Invitación revocada",
         "deal_created": "Deal creado",
         "deal_funded": "Deal financiado"
       }

--- a/supabase/migrations/20260829000100_restore_referral_invitation_attribution.sql
+++ b/supabase/migrations/20260829000100_restore_referral_invitation_attribution.sql
@@ -1,0 +1,201 @@
+-- Issue #160: restore invitation attribution in handle_new_user (kept admin rejection),
+-- allow one-time late attribution when columns are still null, extend referral event types,
+-- and convert invitations on attribution updates as well as inserts.
+
+-- ---------------------------------------------------------------------------
+-- Event types: signup_started + invitation_revoked
+-- ---------------------------------------------------------------------------
+alter table public.referral_events
+  drop constraint if exists referral_events_event_type_check;
+
+alter table public.referral_events
+  add constraint referral_events_event_type_check
+  check (event_type in (
+    'invitation_created',
+    'link_opened',
+    'signup_started',
+    'account_created',
+    'onboarding_completed',
+    'invitation_revoked',
+    'deal_created',
+    'deal_funded'
+  ));
+
+create unique index if not exists supplier_referral_invitations_token_hash_uidx
+  on public.supplier_referral_invitations (token_hash);
+
+-- ---------------------------------------------------------------------------
+-- handle_new_user: reject admin + resolve invitation / legacy referral metadata
+-- ---------------------------------------------------------------------------
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  meta_type text := nullif(trim(coalesce(new.raw_user_meta_data->>'user_type', '')), '');
+  resolved_type text;
+  v_referred_by uuid;
+  v_invitation_id uuid;
+begin
+  -- Onboarding roles only. 'admin' is ignored the same way as unknown values.
+  if meta_type in ('pyme', 'investor', 'supplier') then
+    resolved_type := meta_type;
+  else
+    resolved_type := null;
+  end if;
+
+  -- Opaque invitation path (signup metadata carries invitation id from resolved token).
+  if new.raw_user_meta_data->>'referral_invitation_id' is not null then
+    begin
+      v_invitation_id := (new.raw_user_meta_data->>'referral_invitation_id')::uuid;
+      select i.supplier_company_id into v_referred_by
+      from public.supplier_referral_invitations i
+      where i.id = v_invitation_id
+        and i.status = 'active'
+        and (i.expires_at is null or i.expires_at > now());
+      if v_referred_by is null then
+        v_invitation_id := null;
+      end if;
+    exception when others then
+      v_invitation_id := null;
+      v_referred_by := null;
+    end;
+  end if;
+
+  -- Legacy UUID referral compatibility.
+  if v_referred_by is null and new.raw_user_meta_data->>'referred_by_supplier_id' is not null then
+    begin
+      v_referred_by := (new.raw_user_meta_data->>'referred_by_supplier_id')::uuid;
+      if not exists (select 1 from public.supplier_companies where id = v_referred_by) then
+        v_referred_by := null;
+      end if;
+    exception when others then
+      v_referred_by := null;
+    end;
+  end if;
+
+  insert into public.profiles (
+    id,
+    email,
+    user_type,
+    company_name,
+    contact_name,
+    full_name,
+    referred_by_supplier_id,
+    referral_invitation_id
+  )
+  values (
+    new.id,
+    new.email,
+    resolved_type,
+    coalesce(new.raw_user_meta_data->>'company_name', null),
+    coalesce(new.raw_user_meta_data->>'contact_name', new.raw_user_meta_data->>'full_name', null),
+    coalesce(new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'contact_name', null),
+    v_referred_by,
+    v_invitation_id
+  )
+  on conflict (id) do nothing;
+
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Immutability: freeze attribution once set; allow null → value once (onboarding)
+-- ---------------------------------------------------------------------------
+create or replace function public.lock_referred_by_supplier_id()
+returns trigger
+language plpgsql
+as $$
+begin
+  if old.referred_by_supplier_id is not null then
+    new.referred_by_supplier_id := old.referred_by_supplier_id;
+  end if;
+  if old.referral_invitation_id is not null then
+    new.referral_invitation_id := old.referral_invitation_id;
+  end if;
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Conversion + account_created on insert OR first-time attribution update
+-- ---------------------------------------------------------------------------
+create or replace function public.after_profile_referral_attribution()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invitation_id uuid;
+  v_supplier_id uuid;
+  already_logged boolean;
+begin
+  if tg_op = 'UPDATE' then
+    -- Only act when attribution is newly applied.
+    if old.referred_by_supplier_id is not null
+       or new.referred_by_supplier_id is null then
+      return new;
+    end if;
+  end if;
+
+  v_supplier_id := new.referred_by_supplier_id;
+  v_invitation_id := new.referral_invitation_id;
+
+  if v_supplier_id is null then
+    return new;
+  end if;
+
+  if v_invitation_id is not null then
+    update public.supplier_referral_invitations
+    set
+      status = 'converted',
+      converted_profile_id = new.id,
+      updated_at = now()
+    where id = v_invitation_id
+      and status = 'active';
+  end if;
+
+  select exists (
+    select 1
+    from public.referral_events re
+    where re.profile_id = new.id
+      and re.event_type = 'account_created'
+      and (
+        (v_invitation_id is not null and re.invitation_id = v_invitation_id)
+        or (v_invitation_id is null and re.supplier_company_id = v_supplier_id)
+      )
+  ) into already_logged;
+
+  if not already_logged then
+    insert into public.referral_events (
+      invitation_id,
+      supplier_company_id,
+      profile_id,
+      event_type
+    ) values (
+      v_invitation_id,
+      v_supplier_id,
+      new.id,
+      'account_created'
+    );
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_referral_attribution_after_insert on public.profiles;
+create trigger profiles_referral_attribution_after_insert
+  after insert on public.profiles
+  for each row
+  execute function public.after_profile_referral_attribution();
+
+drop trigger if exists profiles_referral_attribution_after_update on public.profiles;
+create trigger profiles_referral_attribution_after_update
+  after update of referred_by_supplier_id, referral_invitation_id on public.profiles
+  for each row
+  execute function public.after_profile_referral_attribution();

--- a/supabase/migrations/20260829000100_restore_referral_invitation_attribution.sql
+++ b/supabase/migrations/20260829000100_restore_referral_invitation_attribution.sql
@@ -46,34 +46,38 @@ begin
     resolved_type := null;
   end if;
 
-  -- Opaque invitation path (signup metadata carries invitation id from resolved token).
-  if new.raw_user_meta_data->>'referral_invitation_id' is not null then
-    begin
-      v_invitation_id := (new.raw_user_meta_data->>'referral_invitation_id')::uuid;
-      select i.supplier_company_id into v_referred_by
-      from public.supplier_referral_invitations i
-      where i.id = v_invitation_id
-        and i.status = 'active'
-        and (i.expires_at is null or i.expires_at > now());
-      if v_referred_by is null then
+  -- Defer invitation / legacy attribution until the account role is known to be pyme.
+  -- Signup usually omits user_type; onboarding applies attribution once the role is chosen.
+  if resolved_type = 'pyme' then
+    -- Opaque invitation path (signup metadata carries invitation id from resolved token).
+    if new.raw_user_meta_data->>'referral_invitation_id' is not null then
+      begin
+        v_invitation_id := (new.raw_user_meta_data->>'referral_invitation_id')::uuid;
+        select i.supplier_company_id into v_referred_by
+        from public.supplier_referral_invitations i
+        where i.id = v_invitation_id
+          and i.status = 'active'
+          and (i.expires_at is null or i.expires_at > now());
+        if v_referred_by is null then
+          v_invitation_id := null;
+        end if;
+      exception when others then
         v_invitation_id := null;
-      end if;
-    exception when others then
-      v_invitation_id := null;
-      v_referred_by := null;
-    end;
-  end if;
-
-  -- Legacy UUID referral compatibility.
-  if v_referred_by is null and new.raw_user_meta_data->>'referred_by_supplier_id' is not null then
-    begin
-      v_referred_by := (new.raw_user_meta_data->>'referred_by_supplier_id')::uuid;
-      if not exists (select 1 from public.supplier_companies where id = v_referred_by) then
         v_referred_by := null;
-      end if;
-    exception when others then
-      v_referred_by := null;
-    end;
+      end;
+    end if;
+
+    -- Legacy UUID referral compatibility.
+    if v_referred_by is null and new.raw_user_meta_data->>'referred_by_supplier_id' is not null then
+      begin
+        v_referred_by := (new.raw_user_meta_data->>'referred_by_supplier_id')::uuid;
+        if not exists (select 1 from public.supplier_companies where id = v_referred_by) then
+          v_referred_by := null;
+        end if;
+      exception when others then
+        v_referred_by := null;
+      end;
+    end if;
   end if;
 
   insert into public.profiles (
@@ -123,6 +127,63 @@ $$;
 -- ---------------------------------------------------------------------------
 -- Conversion + account_created on insert OR first-time attribution update
 -- ---------------------------------------------------------------------------
+-- Claim invitation atomically before attribution is retained (avoids TOCTOU).
+create or replace function public.claim_referral_attribution_before_write()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_supplier uuid;
+begin
+  -- Strip pending attribution until the profile role is pyme.
+  if new.user_type is distinct from 'pyme' then
+    if tg_op = 'INSERT' or old.referred_by_supplier_id is null then
+      new.referred_by_supplier_id := null;
+    end if;
+    if tg_op = 'INSERT' or old.referral_invitation_id is null then
+      new.referral_invitation_id := null;
+    end if;
+    return new;
+  end if;
+
+  -- Already attributed — immutability trigger keeps prior values.
+  if tg_op = 'UPDATE' and old.referred_by_supplier_id is not null then
+    return new;
+  end if;
+
+  if new.referral_invitation_id is not null then
+    update public.supplier_referral_invitations
+    set
+      status = 'converted',
+      converted_profile_id = new.id,
+      updated_at = now()
+    where id = new.referral_invitation_id
+      and status = 'active'
+      and (expires_at is null or expires_at > now())
+    returning supplier_company_id into v_supplier;
+
+    if v_supplier is null then
+      -- Lost the race or invitation inactive: do not retain attribution.
+      new.referral_invitation_id := null;
+      new.referred_by_supplier_id := null;
+    else
+      new.referred_by_supplier_id := v_supplier;
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_claim_referral_attribution on public.profiles;
+create trigger profiles_claim_referral_attribution
+  before insert or update of referred_by_supplier_id, referral_invitation_id, user_type
+  on public.profiles
+  for each row
+  execute function public.claim_referral_attribution_before_write();
+
 create or replace function public.after_profile_referral_attribution()
 returns trigger
 language plpgsql
@@ -133,7 +194,12 @@ declare
   v_invitation_id uuid;
   v_supplier_id uuid;
   already_logged boolean;
+  claim_ok boolean := true;
 begin
+  if new.user_type is distinct from 'pyme' then
+    return new;
+  end if;
+
   if tg_op = 'UPDATE' then
     -- Only act when attribution is newly applied.
     if old.referred_by_supplier_id is not null
@@ -150,13 +216,17 @@ begin
   end if;
 
   if v_invitation_id is not null then
-    update public.supplier_referral_invitations
-    set
-      status = 'converted',
-      converted_profile_id = new.id,
-      updated_at = now()
-    where id = v_invitation_id
-      and status = 'active';
+    select exists (
+      select 1
+      from public.supplier_referral_invitations i
+      where i.id = v_invitation_id
+        and i.status = 'converted'
+        and i.converted_profile_id = new.id
+    ) into claim_ok;
+
+    if not claim_ok then
+      return new;
+    end if;
   end if;
 
   select exists (

--- a/supabase/migrations/20260829000200_fix_referral_dashboard_cte_scope.sql
+++ b/supabase/migrations/20260829000200_fix_referral_dashboard_cte_scope.sql
@@ -1,0 +1,163 @@
+-- Fix CTE scope bugs in referral dashboard RPCs.
+-- Postgres WITH clauses only apply to the immediately following statement;
+-- the second SELECT could not see "combined" / "events".
+
+create or replace function public.get_supplier_referred_pymes_page(
+  p_owner_id uuid,
+  p_company_id uuid default null,
+  p_limit int default 20,
+  p_offset int default 0
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_companies uuid[];
+  v_total int;
+  v_rows jsonb;
+begin
+  if p_owner_id is distinct from auth.uid() then
+    raise exception 'forbidden';
+  end if;
+
+  v_companies := public.get_supplier_owned_company_ids(p_owner_id, p_company_id);
+
+  with referred as (
+    select
+      p.id as profile_id,
+      p.referred_by_supplier_id as supplier_company_id,
+      sc.company_name as supplier_company_name,
+      p.referral_invitation_id,
+      case when p.referral_invitation_id is null then 'legacy' else 'invitation' end as attribution_source,
+      p.company_name,
+      p.full_name,
+      p.contact_name,
+      p.bio,
+      p.country,
+      p.sector,
+      p.user_type,
+      p.verified,
+      coalesce(dc.deal_count, 0) as deal_count,
+      coalesce(dc.requested_volume, 0) as requested_volume,
+      coalesce(dc.funded_volume, 0) as funded_volume,
+      p.created_at
+    from public.profiles p
+    join public.supplier_companies sc on sc.id = p.referred_by_supplier_id
+    left join lateral (
+      select
+        count(*)::int as deal_count,
+        coalesce(sum(d.amount) filter (where d.status <> 'cancelled'), 0) as requested_volume,
+        coalesce(sum(d.amount) filter (where d.status in ('funded','in_progress','completed')), 0) as funded_volume
+      from public.deals d
+      where d.pyme_id = p.id
+    ) dc on true
+    where p.referred_by_supplier_id = any(v_companies)
+  ),
+  invited_only as (
+    select
+      i.converted_profile_id as profile_id,
+      i.supplier_company_id,
+      sc.company_name as supplier_company_name,
+      i.id as referral_invitation_id,
+      'invitation' as attribution_source,
+      null::text as company_name,
+      null::text as full_name,
+      null::text as contact_name,
+      null::text as bio,
+      null::text as country,
+      null::text as sector,
+      null::text as user_type,
+      null::boolean as verified,
+      0 as deal_count,
+      0::numeric as requested_volume,
+      0::numeric as funded_volume,
+      i.created_at
+    from public.supplier_referral_invitations i
+    join public.supplier_companies sc on sc.id = i.supplier_company_id
+    where i.supplier_company_id = any(v_companies)
+      and i.converted_profile_id is null
+      and i.status in ('active', 'expired')
+  ),
+  combined as (
+    select * from referred
+    union all
+    select * from invited_only
+  )
+  select
+    (select count(*)::int from combined),
+    coalesce(
+      (
+        select jsonb_agg(row_to_json(t))
+        from (
+          select *
+          from combined
+          order by created_at desc nulls last
+          limit greatest(p_limit, 1)
+          offset greatest(p_offset, 0)
+        ) t
+      ),
+      '[]'::jsonb
+    )
+  into v_total, v_rows;
+
+  return jsonb_build_object('total', v_total, 'rows', v_rows);
+end;
+$$;
+
+create or replace function public.get_supplier_referral_activity_page(
+  p_owner_id uuid,
+  p_company_id uuid default null,
+  p_limit int default 30,
+  p_offset int default 0
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_companies uuid[];
+  v_total int;
+  v_rows jsonb;
+begin
+  if p_owner_id is distinct from auth.uid() then
+    raise exception 'forbidden';
+  end if;
+
+  v_companies := public.get_supplier_owned_company_ids(p_owner_id, p_company_id);
+
+  with events as (
+    select
+      e.id,
+      e.event_type,
+      e.created_at,
+      e.profile_id,
+      e.invitation_id,
+      e.metadata
+    from public.referral_events e
+    where e.supplier_company_id = any(v_companies)
+  )
+  select
+    (select count(*)::int from events),
+    coalesce(
+      (
+        select jsonb_agg(row_to_json(t))
+        from (
+          select *
+          from events
+          order by created_at desc
+          limit greatest(p_limit, 1)
+          offset greatest(p_offset, 0)
+        ) t
+      ),
+      '[]'::jsonb
+    )
+  into v_total, v_rows;
+
+  return jsonb_build_object('total', v_total, 'rows', v_rows);
+end;
+$$;

--- a/supabase/migrations/20260829000200_fix_referral_dashboard_cte_scope.sql
+++ b/supabase/migrations/20260829000200_fix_referral_dashboard_cte_scope.sql
@@ -94,7 +94,7 @@ begin
         from (
           select *
           from combined
-          order by created_at desc nulls last
+          order by created_at desc nulls last, profile_id nulls last, referral_invitation_id nulls last
           limit greatest(p_limit, 1)
           offset greatest(p_offset, 0)
         ) t
@@ -149,7 +149,7 @@ begin
         from (
           select *
           from events
-          order by created_at desc
+          order by created_at desc, id
           limit greatest(p_limit, 1)
           offset greatest(p_offset, 0)
         ) t


### PR DESCRIPTION
# PR: Supplier referral invitation attribution

 Closes #160

## Summary

Restores opaque invitation attribution after the admin-signup migration overwrote `handle_new_user`, completes invite lifecycle events, and fixes the referrals dashboard RPC crash on a fresh database.

- Restore invitation + legacy referral resolution in `handle_new_user` while keeping admin rejection
- Allow one-time late attribution (`null` → value), then keep it immutable
- Convert invitations on first attribution (insert or update)
- Add `signup_started` and `invitation_revoked` events
- Preserve `mercato-invite` through signup, auth callback, and PyME onboarding
- Fix dashboard CTE scope (`relation "combined" does not exist`)
- Harden invitation create so event-logging failures do not break the API response

## Test plan

- [x] Supplier with a company can create an invitation and copy an opaque `?invite=` link
- [x] Opening the link shows the supplier company on signup
- [x] New user signs up via invite, onboards as **PyME**
- [x] Profile has `referred_by_supplier_id` and `referral_invitation_id`
- [x] Invitation status becomes `converted`
- [x] Events include at least `invitation_created`, `link_opened`, `signup_started`, `account_created`
- [x] Revoked invitation cannot attribute a new user
- [x] Legacy `?ref=<supplier_company_uuid>` still attributes company only
- [x] `/dashboard/referrals` loads without the `combined` relation error
- [x] `bun test __tests__/referrals` passes
- [x] `bun lint` and `bun build` pass

## Evidence

**Create invitation dialog**
<img width="1920" height="1201" alt="Screenshot 2026-08-30 at 1 11 17 AM" src="https://github.com/user-attachments/assets/5c02befa-ba9a-48be-b8e0-a0981b7e1ac1" />

 **Invite link created**
<img width="1920" height="1200" alt="Screenshot 2026-08-30 at 1 12 08 AM" src="https://github.com/user-attachments/assets/2dfb8249-4da0-4613-b627-3cb1543a1010" />

**Referred signup**

<img width="1726" height="1165" alt="Screenshot 2026-08-30 at 1 14 46 AM" src="https://github.com/user-attachments/assets/f02b1c21-726f-4749-bf46-6f6c7e7b6a97" />
<img width="1727" height="1165" alt="Screenshot 2026-08-30 at 1 15 08 AM" src="https://github.com/user-attachments/assets/5967bf07-7636-41ef-8888-262054835939" />


**Supplier referrals dashboard after conversion**
<img width="1723" height="1162" alt="Screenshot 2026-08-30 at 1 16 28 AM" src="https://github.com/user-attachments/assets/7d10b1d6-deb7-4da9-ac42-6ff93b210d1e" />


**Supabase Table Editor**
<img width="1724" height="791" alt="Screenshot 2026-08-30 at 1 18 02 AM" src="https://github.com/user-attachments/assets/18d3d1da-9894-408e-9457-5795e32a635a" />

**Passing Tests**
<img width="907" height="699" alt="Screenshot 2026-08-30 at 1 19 34 AM" src="https://github.com/user-attachments/assets/40045565-8121-4a72-b400-a7845bb99d4c" />

## Notes for reviewers

- New migrations (apply on deploy / local DB):
  - `20260829000100_restore_referral_invitation_attribution.sql`
  - `20260829000200_fix_referral_dashboard_cte_scope.sql`
- Server-side invitation event logging uses the service role client; local `.env.local` needs `SUPABASE_SERVICE_ROLE_KEY` for full event writes (create still succeeds if logging is skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invite-based referral attribution throughout sign-up and onboarding.
  * Added referral tracking for sign-up initiation and revoked invitations.
  * Added paginated referral activity and referred-profile dashboard data.
  * Preserved invite information across authentication redirects.

* **Bug Fixes**
  * Improved handling of already-revoked invitations and referral service errors.
  * Added clearer invitation creation error messages and validation.

* **Localization**
  * Added English and Spanish labels for new referral activity events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->